### PR TITLE
Use icon GIF for packages panel: Add horizontal scrollbar if required; Update text for nav links

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -1527,8 +1527,8 @@ loginManager.addEventListener('inventorychange', async e => {
 
 const _makePackageHtml = p => `
   <div class=package draggable=true>
-    <img src="assets/question.png">
-    <!-- <img src="${p.img}" width=256 height=256> -->
+    <!-- <img src="assets/question.png"> -->
+    <img src="${apiHost}/${p.icons[0].hash}.gif" width=256 height=256>
     <div class=text>
       <div class=name>${p.name}</div>
     </div>

--- a/index.css
+++ b/index.css
@@ -594,12 +594,12 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   right: 0;
   bottom: 0;
   width: 100vw;
-  height: 200px;
+  min-height: 200px;
   /* padding: 20px; */
   background-color: #111;
   color: #FFF;
-  /* box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08);
-  overflow: auto; */
+  /* box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08); */
+  overflow: auto;
 }
 
 .subpage:not(.open) {

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
           <i class="fa fa-pencil"></i>
           <div class=wrap>
             <h3>Edit mode</h3>
-            <p>You are currently editing this world</p>
+            <p>Switch to edit mode</p>
           </div>
         </a>
         <a href="browse.html" class=selection>

--- a/login.html
+++ b/login.html
@@ -27,7 +27,7 @@
           <i class="fa fa-pencil"></i>
           <div class=wrap>
             <h3>Edit mode</h3>
-            <p>You are currently editing this world</p>
+            <p>Switch to edit mode</p>
           </div>
         </a>
         <a href="browse.html" class="selection dim">

--- a/run.html
+++ b/run.html
@@ -24,14 +24,14 @@
           <i class="fa fa-play"></i>
           <div class=wrap>
             <h3>Run mode</h3>
-            <p>Switch to run mode</p>
+            <p>You are currently in run mode</p>
           </div>
         </a>
         <a href="edit.html" class=selection id=edit-mode>
           <i class="fa fa-pencil"></i>
           <div class=wrap>
             <h3>Edit mode</h3>
-            <p>You are currently editing this world</p>
+            <p>Switch to edit mode</p>
           </div>
         </a>
         <a href="browse.html" class=selection>


### PR DESCRIPTION
This PR mainly affects the packages panel on the /edit.html page

- Adds a horizontal scrollbar if there is more content to be seen
- Uses the package's icon GIF for the XRPK rather than the question mark icon placeholder:

!['after' view](https://user-images.githubusercontent.com/8850830/85860834-46074080-b7b7-11ea-9485-d979a340756d.png)

For reference, this is what it looks like [right now](https://xrpackage.org/edit.html?w=8cdc5qwp):

!['before' view](https://user-images.githubusercontent.com/8850830/85860892-5fa88800-b7b7-11ea-9f8f-8ead037a5bf5.png)

---

I've also updated the navigation bar items to use the correct text, e.g. `Switch to edit mode` if you're on the homepage, rather than `You are currently editing this world`, which should only be there when you're on the /edit.html page