### PR TITLE
Refactor edit.js

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -13,6 +13,14 @@ import './gif.js';
 import {makeLineMesh, makeTeleportMesh} from './teleport.js';
 
 import targetMeshGeometry from './edit/targetMeshGeometry.js';
+import attachEventListeners from './edit/classlistHandlers.js';
+import {
+  worldSaveButton, worldRevertButton, micButton, dropdownButton, sandboxButton, newWorldButton,
+  packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
+  tabs, tabContents, inventorySubtabContent,
+  runMode, editMode,
+  dropdown,
+} from './edit/domElements.js';
 
 const apiHost = 'https://ipfs.exokit.org/ipfs';
 const presenceEndpoint = 'wss://presence.exokit.org';
@@ -1009,98 +1017,6 @@ renderer.domElement.addEventListener('mousedown', e => {
   }
 }); */
 
-// const runMode = document.getElementById('run-mode');
-// const editMode = document.getElementById('edit-mode');
-
-const worldsButton = document.getElementById('worlds-button');
-const worldSaveButton = document.getElementById('world-save-button');
-const worldRevertButton = document.getElementById('world-revert-button');
-const packagesButton = document.getElementById('packages-button');
-const inventoryButton = document.getElementById('inventory-button');
-const avatarButton = document.getElementById('avatar-button');
-const micButton = document.getElementById('mic-button');
-const dropdownButton = document.getElementById('dropdown-button');
-const dropdown = document.getElementById('dropdown');
-const worldsSubpage = document.getElementById('worlds-subpage');
-const packagesSubpage = document.getElementById('packages-subpage');
-const inventorySubpage = document.getElementById('inventory-subpage');
-const avatarSubpage = document.getElementById('avatar-subpage');
-const avatarSubpageContent = avatarSubpage.querySelector('.subtab-content');
-const tabs = Array.from(dropdown.querySelectorAll('.tab'));
-const tabContents = Array.from(dropdown.querySelectorAll('.tab-content'));
-const worldsSubtabs = Array.from(worldsSubpage.querySelectorAll('.subtab'));
-const worldsCloseButton = worldsSubpage.querySelector('.close-button');
-const worldsSubtabContents = Array.from(worldsSubpage.querySelectorAll('.subtab-content'));
-const packagesCloseButton = packagesSubpage.querySelector('.close-button');
-const inventorySubtabs = Array.from(inventorySubpage.querySelectorAll('.subtab'));
-const inventoryCloseButton = inventorySubpage.querySelector('.close-button');
-const inventorySubtabContent = inventorySubpage.querySelector('.subtab-content');
-const avatarCloseButton = avatarSubpage.querySelector('.close-button');
-worldsButton.addEventListener('click', e => {
-  worldsButton.classList.toggle('open');
-  worldsSubpage.classList.toggle('open');
-
-  dropdownButton.classList.remove('open');
-  dropdown.classList.remove('open');
-  packagesButton.classList.remove('open');
-  packagesSubpage.classList.remove('open');
-  inventoryButton.classList.remove('open');
-  inventorySubpage.classList.remove('open');
-  avatarButton.classList.remove('open');
-  avatarSubpage.classList.remove('open');
-});
-packagesButton.addEventListener('click', e => {
-  packagesButton.classList.add('open');
-  packagesSubpage.classList.add('open');
-
-  dropdownButton.classList.remove('open');
-  dropdown.classList.remove('open');
-  inventoryButton.classList.remove('open');
-  inventorySubpage.classList.remove('open');
-  worldsButton.classList.remove('open');
-  worldsSubpage.classList.remove('open');
-  avatarButton.classList.remove('open');
-  avatarSubpage.classList.remove('open');
-});
-inventoryButton.addEventListener('click', e => {
-  inventoryButton.classList.toggle('open');
-  inventorySubpage.classList.toggle('open');
-
-  dropdownButton.classList.remove('open');
-  dropdown.classList.remove('open');
-  packagesButton.classList.remove('open');
-  packagesSubpage.classList.remove('open');
-  worldsButton.classList.remove('open');
-  worldsSubpage.classList.remove('open');
-  avatarButton.classList.remove('open');
-  avatarSubpage.classList.remove('open');
-});
-avatarButton.addEventListener('click', e => {
-  avatarButton.classList.toggle('open');
-  avatarSubpage.classList.toggle('open');
-
-  dropdownButton.classList.remove('open');
-  dropdown.classList.remove('open');
-  packagesButton.classList.remove('open');
-  packagesSubpage.classList.remove('open');
-  worldsButton.classList.remove('open');
-  worldsSubpage.classList.remove('open');
-  inventoryButton.classList.remove('open');
-  inventorySubpage.classList.remove('open');
-});
-dropdownButton.addEventListener('click', e => {
-  dropdownButton.classList.toggle('open');
-  dropdown.classList.toggle('open');
-
-  worldsButton.classList.remove('open');
-  packagesButton.classList.remove('open');
-  packagesSubpage.classList.remove('open');
-  inventoryButton.classList.remove('open');
-  inventorySubpage.classList.remove('open');
-  worldsSubpage.classList.remove('open');
-  avatarButton.classList.remove('open');
-  avatarSubpage.classList.remove('open');
-});
 micButton.addEventListener('click', async e => {
   micButton.classList.toggle('enabled');
   if (micButton.classList.contains('enabled')) {
@@ -1159,20 +1075,7 @@ for (let i = 0; i < inventorySubtabs.length; i++) {
     subtabContent.classList.add('open');
   });
 } */
-[worldsCloseButton, packagesCloseButton, inventoryCloseButton, avatarCloseButton].forEach(closeButton => {
-  closeButton.addEventListener('click', e => {
-    dropdownButton.classList.remove('open');
-    dropdown.classList.remove('open');
-    packagesButton.classList.remove('open');
-    packagesSubpage.classList.remove('open');
-    worldsButton.classList.remove('open');
-    worldsSubpage.classList.remove('open');
-    inventoryButton.classList.remove('open');
-    inventorySubpage.classList.remove('open');
-    avatarButton.classList.remove('open');
-    avatarSubpage.classList.remove('open');
-  });
-});
+
 async function screenshotEngine() {
   const center = new THREE.Vector3(0, 0, 0);
   const size = new THREE.Vector3(3, 3, 3);
@@ -1812,7 +1715,7 @@ publishWorldButton.addEventListener('click', async e => {
     console.warn('invalid status code: ' + res.status);
   }
 }); */
-const sandboxButton = document.getElementById('sandbox-button');
+
 sandboxButton.addEventListener('click', e => {
   _pushWorld(null);
 });
@@ -1825,7 +1728,7 @@ function makeId(length) {
   }
   return result;
 }
-const newWorldButton = document.getElementById('new-world-button');
+
 newWorldButton.addEventListener('click', async e => {
   pe.reset();
   const hash = await pe.uploadScene();
@@ -2238,3 +2141,5 @@ window.addEventListener('popstate', e => {
   _handleUrl(window.location.href);
 });
 _handleUrl(window.location.href);
+
+attachEventListeners();

--- a/edit.js
+++ b/edit.js
@@ -1,7 +1,5 @@
-/* global Web3 */
 /* eslint no-unused-vars: 0 */
 import * as THREE from 'https://static.xrpackage.org/xrpackage/three.module.js';
-import {BufferGeometryUtils} from 'https://static.xrpackage.org/BufferGeometryUtils.js';
 import {TransformControls} from './TransformControls.js';
 // import address from 'https://contracts.webaverse.com/address.js';
 // import abi from 'https://contracts.webaverse.com/abi.js';
@@ -11,23 +9,19 @@ import {wireframeMaterial, getWireframeMesh, meshIdToArray, decorateRaycastMesh,
 // import {makeWristMenu, makeHighlightMesh, makeRayMesh} from './vr-ui.js';
 import {makeLineMesh, makeTeleportMesh} from './teleport.js';
 
+import {handleUrl, addPackage} from './edit/utils.js';
 import targetMeshGeometry from './edit/targetMeshGeometry.js';
 import attachEventListeners from './edit/classlistHandlers.js';
 import dragHandlers from './edit/dragHandlers.js';
-import screenshotEngine from './edit/screenshotEngine.js';
+import {updateWorldSaveButton, worldHandlers} from './edit/worlds.js';
+import {apiHost, packagesEndpoint, contract} from './edit/constants.js';
 import {
-  worldSaveButton, worldRevertButton, micButton, dropdownButton, sandboxButton, newWorldButton,
   packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
   tabs, tabContents, inventorySubtabContent,
   scaleSlider, shieldSlider,
-  runMode, editMode,
+  micButton, dropdownButton,
   dropdown,
 } from './edit/domElements.js';
-
-const apiHost = 'https://ipfs.exokit.org/ipfs';
-const presenceEndpoint = 'wss://presence.exokit.org';
-const worldsEndpoint = 'https://worlds.exokit.org';
-const packagesEndpoint = 'https://packages.exokit.org';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -49,10 +43,8 @@ const keys = {
 
 let shieldLevel = parseInt(shieldSlider.value, 10);
 let selectedTool = 'camera';
-let currentWorldId = '';
 let hoverTarget = null;
 let selectTarget = null;
-let currentWorldChanged = false;
 let jumpState = null;
 
 const _resetKeys = () => {
@@ -60,16 +52,6 @@ const _resetKeys = () => {
     keys[k] = false;
   }
 };
-
-function parseQuery(queryString) {
-  var query = {};
-  var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
-  for (var i = 0; i < pairs.length; i++) {
-    var pair = pairs[i].split('=');
-    query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
-  }
-  return query;
-}
 
 const targetVsh = `
   #define M_PI 3.1415926535897932384626433832795
@@ -771,9 +753,9 @@ const loadMeshMaterial = new THREE.ShaderMaterial({
   side: THREE.DoubleSide,
 });
 const _makeLoadMesh = (() => {
-  const geometry = new THREE.RingBufferGeometry(0.05, 0.08, 128, 0, Math.PI/2, Math.PI*2*0.9)
-    // .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI)));
-  return() => {
+  const geometry = new THREE.RingBufferGeometry(0.05, 0.08, 128, 0, Math.PI / 2, Math.PI * 2 * 0.9);
+  // .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI)));
+  return () => {
     const mesh = new THREE.Mesh(geometry, loadMeshMaterial);
     // mesh.frustumCulled = false;
     return mesh;
@@ -873,10 +855,7 @@ const _packageadd = async e => {
 
   _bindObject(p);
 
-  if (!reason) {
-    currentWorldChanged = true;
-    _updateWorldSaveButton();
-  }
+  if (!reason) updateWorldSaveButton(true);
 };
 const _packageremove = e => {
   const {
@@ -900,21 +879,9 @@ const _packageremove = e => {
 
   _unbindObject(p);
 
-  if (!reason) {
-    currentWorldChanged = true;
-    _updateWorldSaveButton();
-  }
+  if (!reason) updateWorldSaveButton(true);
 };
 
-const _updateWorldSaveButton = () => {
-  if (currentWorldChanged && currentWorldId) {
-    worldSaveButton.classList.remove('hidden');
-    worldRevertButton.classList.remove('hidden');
-  } else {
-    worldSaveButton.classList.add('hidden');
-    worldRevertButton.classList.add('hidden');
-  }
-};
 function _matrixUpdate(e) {
   const p = this;
   const matrix = e.data;
@@ -1081,164 +1048,6 @@ for (let i = 0; i < inventorySubtabs.length; i++) {
   });
 } */
 
-worldSaveButton.addEventListener('click', async e => {
-  const {name} = pe;
-  const hash = await pe.uploadScene();
-
-  const screenshotBlob = await screenshotEngine(pe);
-  const {hash: previewIconHash} = await fetch(`${apiHost}/`, {
-    method: 'PUT',
-    body: screenshotBlob,
-  })
-    .then(res => res.json());
-
-  const objects = await Promise.all(pe.children.map(async p => {
-    const {name, hash} = p;
-    const previewIconHash = await (async () => {
-      const screenshotImgUrl = await p.getScreenshotImageUrl();
-      if (screenshotImgUrl) {
-        const screenshotBlob = await fetch(screenshotImgUrl)
-          .then(res => res.blob());
-        const {hash: previewIconHash} = await fetch(`${apiHost}/`, {
-          method: 'PUT',
-          body: screenshotBlob,
-        })
-          .then(res => res.json());
-        return previewIconHash;
-      } else {
-        return null;
-      }
-    })();
-    return {
-      name,
-      previewIconHash,
-    };
-  }));
-  const w = {
-    id: currentWorldId,
-    name,
-    description: 'This is a world description',
-    hash,
-    previewIconHash,
-    objects,
-  };
-  const res = await fetch(worldsEndpoint + '/' + currentWorldId, {
-    method: 'PUT',
-    body: JSON.stringify(w),
-  });
-  if (res.ok) {
-    // nothing
-  } else {
-    console.warn('invalid status code: ' + res.status);
-  }
-
-  currentWorldChanged = false;
-  _updateWorldSaveButton();
-});
-worldRevertButton.addEventListener('click', async e => {
-  _enterWorld(currentWorldId);
-});
-
-const worlds = document.getElementById('worlds');
-const _makeWorldHtml = w => `
-  <div class="world ${currentWorldId === w.id ? 'open' : ''}" worldId="${w.id}">
-    <img src=assets/question.png>
-    <div class="text">
-      <input type=text class=name-input value="${w.name}" disabled>
-    </div>
-    <div class=background>
-      <nav class="button rename-button">Rename</nav>
-    </div>
-  </div>
-`;
-
-// const headerLabel = document.getElementById('header-label');
-const _enterWorld = async worldId => {
-  currentWorldId = worldId;
-
-  /* headerLabel.innerText = name || 'Sandbox';
-  runMode.setAttribute('href', 'run.html' + (worldId ? ('?w=' + worldId) : ''));
-  editMode.setAttribute('href', 'edit.html' + (worldId ? ('?w=' + worldId) : '')); */
-
-  const worlds = Array.from(document.querySelectorAll('.world'));
-  worlds.forEach(world => {
-    world.classList.remove('open');
-  });
-  let world;
-  if (worldId) {
-    world = worlds.find(w => w.getAttribute('worldId') === worldId);
-  } else {
-    world = worlds[0];
-  }
-  world && world.classList.add('open');
-
-  if (worldId) {
-    const res = await fetch(worldsEndpoint + '/' + worldId);
-    if (res.ok) {
-      const j = await res.json();
-      const {hash} = j;
-      await pe.downloadScene(hash);
-    } else {
-      console.warn('invalid world status code: ' + worldId + ' ' + res.status);
-    }
-  } else {
-    pe.reset();
-  }
-
-  currentWorldChanged = false;
-  _updateWorldSaveButton();
-};
-const _pushWorld = name => {
-  history.pushState({}, '', window.location.protocol + '//' + window.location.host + window.location.pathname + (name ? ('?w=' + name) : ''));
-  _handleUrl(window.location.href);
-};
-const _bindWorld = w => {
-  w.addEventListener('click', async e => {
-    const worldId = w.getAttribute('worldId');
-    if (worldId !== currentWorldId) {
-      _pushWorld(worldId);
-    }
-  });
-  const nameInput = w.querySelector('.name-input');
-  const renameButton = w.querySelector('.rename-button');
-  let oldValue = '';
-  renameButton.addEventListener('click', e => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    w.classList.add('renaming');
-    oldValue = nameInput.value;
-    nameInput.removeAttribute('disabled');
-    nameInput.select();
-  });
-  nameInput.addEventListener('blur', e => {
-    nameInput.value = oldValue;
-    nameInput.setAttribute('disabled', '');
-    oldValue = '';
-  });
-  nameInput.addEventListener('keydown', e => {
-    if (e.which === 13) { // enter
-      pe.name = nameInput.value;
-      currentWorldChanged = true;
-      _updateWorldSaveButton();
-
-      oldValue = nameInput.value;
-      nameInput.blur();
-    } else if (e.which === 27) { // esc
-      nameInput.blur();
-    }
-  });
-};
-(async () => {
-  const res = await fetch(worldsEndpoint);
-  const children = await res.json();
-  const ws = await Promise.all(children.map(child =>
-    fetch(worldsEndpoint + '/' + child)
-      .then(res => res.json()),
-  ));
-  worlds.innerHTML = ws.map(w => _makeWorldHtml(w)).join('\n');
-  Array.from(worlds.querySelectorAll('.world')).forEach((w, i) => _bindWorld(w, ws[i]));
-})();
 /* let worldType = 'singleplayer';
 const singleplayerButton = document.getElementById('singleplayer-button');
 singleplayerButton.addEventListener('click', e => {
@@ -1352,7 +1161,7 @@ const _changeInventory = inventory => {
           URL.revokeObjectURL(u);
         };
       } else { */
-        img.src = `${apiHost}/${iconHash}.gif`;
+      img.src = `${apiHost}/${iconHash}.gif`;
       // }
     })();
     const wearButton = itemEl.querySelector('.wear-button');
@@ -1389,12 +1198,6 @@ const _makePackageHtml = p => `
     </div>
   </div>
 `;
-async function _addPackage(p, matrix) {
-  if (matrix) {
-    p.setMatrix(matrix);
-  }
-  await pe.add(p);
-}
 const _startPackageDrag = (e, j) => {
   e.dataTransfer.setData('application/json+package', JSON.stringify(j));
   setTimeout(() => {
@@ -1414,7 +1217,7 @@ const _bindPackage = (pE, pJ) => {
   const addButton = pE.querySelector('.add-button');
   addButton.addEventListener('click', async () => {
     const p = await XRPackage.download(dataHash);
-    await _addPackage(p);
+    await addPackage(p, undefined, pe);
   });
   const wearButton = pE.querySelector('.wear-button');
   wearButton.addEventListener('click', () => {
@@ -1475,11 +1278,11 @@ pe.domElement.addEventListener('drop', async e => {
         raycaster.ray.origin.clone()
           .add(raycaster.ray.direction.clone().multiplyScalar(2)),
         new THREE.Quaternion(),
-        new THREE.Vector3(1, 1, 1)
-      )
+        new THREE.Vector3(1, 1, 1),
+      );
 
       const p = await XRPackage.download(dataHash);
-      await _addPackage(p, localMatrix);
+      await addPackage(p, localMatrix, pe);
     }
   }
 });
@@ -1579,46 +1382,6 @@ publishWorldButton.addEventListener('click', async e => {
     console.warn('invalid status code: ' + res.status);
   }
 }); */
-
-sandboxButton.addEventListener('click', e => {
-  _pushWorld(null);
-});
-function makeId(length) {
-  var result = '';
-  var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
-  var charactersLength = characters.length;
-  for (var i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
-  }
-  return result;
-}
-
-newWorldButton.addEventListener('click', async e => {
-  pe.reset();
-  const hash = await pe.uploadScene();
-
-  const worldId = makeId(8);
-  const w = {
-    id: worldId,
-    name: worldId,
-    description: 'This is a world description',
-    hash,
-    objects: [],
-  };
-  const res = await fetch(worldsEndpoint + '/' + w.name, {
-    method: 'PUT',
-    body: JSON.stringify(w),
-  });
-  if (res.ok) {
-    worlds.innerHTML += '\n' + _makeWorldHtml(w);
-    const ws = Array.from(worlds.querySelectorAll('.world'));
-    Array.from(worlds.querySelectorAll('.world')).forEach(w => _bindWorld(w));
-    const newW = ws[ws.length - 1];
-    newW.click();
-  } else {
-    console.warn('invalid status code: ' + res.status);
-  }
-});
 
 const objectsEl = document.getElementById('objects');
 const _getObjectDetailEls = () => {
@@ -1957,54 +1720,16 @@ const _renderObjects = () => {
 
       // wristMenu.objectsSide.setObjects(pe.children);
     } else {
-      objectsEl.innerHTML = `<h1 class=placeholder>No objects in scene</h1>`;
+      objectsEl.innerHTML = '<h1 class=placeholder>No objects in scene</h1>';
     }
   }
 };
 _renderObjects();
-const _handleUrl = async u => {
-  const {search} = new URL(u);
-  const q = parseQuery(search);
-
-  if (q.p) { // package
-    const metadata = await fetch(packagesEndpoint + '/' + q.p)
-      .then(res => res.json())
-    const {dataHash} = metadata;
-
-    const arrayBuffer = await fetch(`${apiHost}/${dataHash}.wbn`)
-      .then(res => res.arrayBuffer());
-
-    const p = new XRPackage(new Uint8Array(arrayBuffer));
-    await _addPackage(p);
-  } else if (q.i) { // index
-    const metadataHash = await contract.methods.getMetadata(parseInt(q.i, 10), 'hash').call();
-    const metadata = await fetch(`${apiHost}/${metadataHash}`)
-      .then(res => res.json());
-    const {dataHash} = metadata;
-
-    const arrayBuffer = await fetch(`${apiHost}/${dataHash}.wbn`)
-      .then(res => res.arrayBuffer());
-
-    const p = new XRPackage(new Uint8Array(arrayBuffer));
-    await _addPackage(p);
-  } else if (q.u) { // url
-    const arrayBuffer = await fetch(q.u)
-      .then(res => res.arrayBuffer());
-
-    const p = new XRPackage(new Uint8Array(arrayBuffer));
-    await pe.add(p);
-  } else if (q.h) { // hash
-    const p = await XRPackage.download(q.h);
-    await _addPackage(p);
-  } else {
-    const w = q.w || null;
-    _enterWorld(w);
-  }
-};
 window.addEventListener('popstate', e => {
-  _handleUrl(window.location.href);
+  handleUrl(window.location.href, pe);
 });
-_handleUrl(window.location.href);
+handleUrl(window.location.href, pe);
 
 attachEventListeners();
 dragHandlers(pe, loginManager);
+worldHandlers(pe);

--- a/edit.js
+++ b/edit.js
@@ -4,7 +4,7 @@ import {TransformControls} from './TransformControls.js';
 // import address from 'https://contracts.webaverse.com/address.js';
 // import abi from 'https://contracts.webaverse.com/abi.js';
 import {XRPackage, pe, renderer, scene, camera, floorMesh, proxySession, getRealSession, loginManager} from './run.js';
-import {downloadFile, readFile, bindUploadFileButton} from 'https://static.xrpackage.org/xrpackage/util.js';
+import {readFile, bindUploadFileButton} from 'https://static.xrpackage.org/xrpackage/util.js';
 import {wireframeMaterial, getWireframeMesh, meshIdToArray, decorateRaycastMesh, VolumeRaycaster} from './volume.js';
 // import {makeWristMenu, makeHighlightMesh, makeRayMesh} from './vr-ui.js';
 import {makeLineMesh, makeTeleportMesh} from './teleport.js';
@@ -679,34 +679,6 @@ window.addEventListener('mouseup', e => {
   lastTeleport = false;
 });
 
-/* document.getElementById('world-name').addEventListener('change', e => {
-  pe.name = e.target.value;
-}); */
-document.getElementById('reset-scene-button').addEventListener('click', e => {
-  pe.reset();
-});
-/* document.getElementById('publish-scene-button').addEventListener('click', async e => {
-  const hash = await pe.uploadScene();
-  const res = await fetch(scenesEndpoint + '/' + hash, {
-    method: 'PUT',
-    body: JSON.stringify({
-      name: pe.name,
-      hash,
-    }),
-  });
-  if (res.ok) {
-    // nothing
-  } else {
-    console.warn('invalid status code: ' + res.status);
-  }
-}); */
-document.getElementById('export-scene-button').addEventListener('click', async e => {
-  const uint8Array = await pe.exportScene();
-  const b = new Blob([uint8Array], {
-    type: 'application/webbundle',
-  });
-  downloadFile(b, 'scene.wbn');
-});
 const loadVsh = `
   #define M_PI 3.1415926535897932384626433832795
   uniform float uTime;
@@ -1017,62 +989,6 @@ for (let i = 0; i < tabs.length; i++) {
     _setSelectTarget(null);
   });
 }
-/* for (let i = 0; i < worldsSubtabs.length; i++) {
-  const subtab = worldsSubtabs[i];
-  const subtabContent = worldsSubtabContents[i];
-  subtab.addEventListener('click', e => {
-    for (let i = 0; i < worldsSubtabs.length; i++) {
-      const subtab = worldsSubtabs[i];
-      const subtabContent = worldsSubtabContents[i];
-      subtab.classList.remove('open');
-      subtabContent.classList.remove('open');
-    }
-
-    subtab.classList.add('open');
-    subtabContent.classList.add('open');
-  });
-}
-for (let i = 0; i < inventorySubtabs.length; i++) {
-  const subtab = inventorySubtabs[i];
-  const subtabContent = inventorySubtabContents[i];
-  subtab.addEventListener('click', e => {
-    for (let i = 0; i < inventorySubtabs.length; i++) {
-      const subtab = inventorySubtabs[i];
-      const subtabContent = inventorySubtabContents[i];
-      subtab.classList.remove('open');
-      subtabContent.classList.remove('open');
-    }
-
-    subtab.classList.add('open');
-    subtabContent.classList.add('open');
-  });
-} */
-
-/* let worldType = 'singleplayer';
-const singleplayerButton = document.getElementById('singleplayer-button');
-singleplayerButton.addEventListener('click', e => {
-  pe.reset();
-
-  singleplayerButton.classList.add('open');
-  multiplayerButton.classList.remove('open');
-  Array.from(worlds.querySelectorAll('.world')).forEach(w => {
-    w.classList.remove('open');
-  });
-  worldType = 'singleplayer';
-  worldTools.style.visibility = null;
-});
-const multiplayerButton = document.getElementById('multiplayer-button');
-multiplayerButton.addEventListener('click', async e => {
-  pe.reset();
-
-  singleplayerButton.classList.remove('open');
-  multiplayerButton.classList.add('open');
-  Array.from(worlds.querySelectorAll('.world')).forEach(w => {
-    w.classList.remove('open');
-  });
-  worldType = 'multiplayer';
-  worldTools.style.visibility = null;
-}); */
 
 window.addEventListener('avatarchange', e => {
   const p = e.data;
@@ -1349,39 +1265,7 @@ pe.domElement.addEventListener('drop', async e => {
       pe.downloadScene(hash);
     });
   });
-})();
-const worldTools = document.getElementById('world-tools');
-const publishWorldButton = document.getElementById('publish-world-button');
-publishWorldButton.addEventListener('click', async e => {
-  let hash;
-  if (worldType === 'singleplayer') {
-    hash = await pe.uploadScene();
-  } else if (worldType === 'multiplayer') {
-    const array = new Uint8Array(32);
-    crypto.getRandomValues(array);
-    hash = Array.prototype.map.call(array, x => ('00' + x.toString(16)).slice(-2)).join('');
-  }
-
-  const w = {
-    name: 'WebXR world',
-    description: 'This is a world description',
-    hash,
-    type: worldType,
-  };
-  const res = await fetch(worldsEndpoint + '/' + hash, {
-    method: 'PUT',
-    body: JSON.stringify(w),
-  });
-  if (res.ok) {
-    worlds.innerHTML += '\n' + _makeWorldHtml(w);
-    const ws = Array.from(worlds.querySelectorAll('.world'));
-    Array.from(worlds.querySelectorAll('.world')).forEach(w => _bindWorld(w));
-    const newW = ws[ws.length - 1];
-    newW.click();
-  } else {
-    console.warn('invalid status code: ' + res.status);
-  }
-}); */
+})(); */
 
 const objectsEl = document.getElementById('objects');
 const _getObjectDetailEls = () => {

--- a/edit.js
+++ b/edit.js
@@ -13,14 +13,13 @@ import {handleUrl, addPackage} from './edit/utils.js';
 import attachEventListeners from './edit/classlistHandlers.js';
 import dragHandlers from './edit/dragHandlers.js';
 import {updateWorldSaveButton, worldHandlers} from './edit/worlds.js';
-import {apiHost, packagesEndpoint, contract, loadMeshMaterial} from './edit/constants.js';
+import {apiHost, contract, loadMeshMaterial} from './edit/constants.js';
 import {ensureLoadMesh, ensurePlaceholdMesh, ensureVolumeMesh} from './edit/meshes.js';
+import {packagesHandlers, startPackageDrag, addPackageFromHash} from './edit/packagesHandlers.js';
 import {
-  packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
-  tabs, tabContents, inventorySubtabContent,
+  tabs, tabContents,
   scaleSlider, shieldSlider,
   micButton, dropdownButton,
-  dropdown,
 } from './edit/domElements.js';
 
 const localVector = new THREE.Vector3();
@@ -856,177 +855,6 @@ for (let i = 0; i < tabs.length; i++) {
   });
 }
 
-window.addEventListener('avatarchange', e => {
-  const p = e.data;
-
-  avatarSubpageContent.innerHTML = `\
-    <div class=avatar draggable=true>
-      <img class=screenshot style="display: none;">
-      <div class=wrap>
-        ${p ? `\
-          <div class=name>${p.name}</div>
-          <div class=hash>${p.hash}</div>
-          <nav class="button unwear-button">Unwear</nab>
-        ` : `\
-          <div class=name>No avatar</div>
-        `}
-      </div>
-    </div>
-  `;
-  if (p) {
-    avatarSubpageContent.addEventListener('dragstart', e => {
-      _startPackageDrag(e, {
-        name: p.name,
-        dataHash: p.hash,
-        iconHash: null,
-      });
-    });
-    (async () => {
-      const img = avatarSubpageContent.querySelector('.screenshot');
-      const u = await p.getScreenshotImageUrl();
-      if (u) {
-        img.src = u;
-        img.onload = () => {
-          img.style.display = null;
-          URL.revokeObjectURL(u);
-        };
-        img.onerror = err => {
-          console.warn(err);
-          URL.revokeObjectURL(u);
-        };
-      } /* else {
-        img.src = 'assets/question.png';
-      } */
-    })();
-    const unwearButton = avatarSubpageContent.querySelector('.unwear-button');
-    unwearButton && unwearButton.addEventListener('click', e => {
-      loginManager.setAvatar(null);
-    });
-  }
-});
-
-const _changeInventory = inventory => {
-  inventorySubtabContent.innerHTML = inventory.map(item => `\
-    <div class=item draggable=true>
-      <img class=screenshot>
-      <div class=name>${item.name}</div>
-      <div class=details>
-        <a class="button inspect-button" target="_blank" href="inspect.html?h=${item.dataHash}">Inspect</a>
-        <nav class="button wear-button">Wear</nav>
-        <nav class="button remove-button">Remove</nav>
-      </div>
-    </div>
-  `).join('\n');
-  const is = inventorySubtabContent.querySelectorAll('.item');
-  is.forEach((itemEl, i) => {
-    const item = inventory[i];
-    const {name, dataHash, iconHash} = item;
-
-    itemEl.addEventListener('dragstart', e => {
-      _startPackageDrag(e, {
-        name,
-        dataHash,
-        iconHash,
-      });
-    });
-
-    (async () => {
-      const img = itemEl.querySelector('.screenshot');
-      /* if (p) {
-        const u = await p.getScreenshotImageUrl();
-        img.src = u;
-        img.onload = () => {
-          URL.revokeObjectURL(u);
-        };
-        img.onerror = err => {
-          console.warn(err);
-          URL.revokeObjectURL(u);
-        };
-      } else { */
-      img.src = `${apiHost}/${iconHash}.gif`;
-      // }
-    })();
-    const wearButton = itemEl.querySelector('.wear-button');
-    wearButton.addEventListener('click', () => {
-      loginManager.setAvatar(dataHash);
-    });
-    const removeButton = itemEl.querySelector('.remove-button');
-    removeButton.addEventListener('click', async () => {
-      console.log('remove', item);
-      const newInventory = inventory.filter(i => i.dataHash !== item.dataHash);
-      await loginManager.setInventory(newInventory);
-    });
-  });
-
-  // wristMenu.inventorySide.setPackages(inventory);
-};
-_changeInventory(loginManager.getInventory());
-loginManager.addEventListener('inventorychange', async e => {
-  const inventory = e.data;
-  _changeInventory(inventory);
-});
-
-const _makePackageHtml = p => `
-  <div class=package draggable=true>
-    <!-- <img src="assets/question.png"> -->
-    <img src="${apiHost}/${p.icons[0].hash}.gif" width=256 height=256>
-    <div class=text>
-      <div class=name>${p.name}</div>
-    </div>
-    <div class=background>
-      <nav class="button add-button">Add</nav>
-      <nav class="button wear-button">Wear</nav>
-      <a class="button inspect-button" target="_blank" href="inspect.html?p=${p.name}">Inspect</a>
-    </div>
-  </div>
-`;
-const _startPackageDrag = (e, j) => {
-  e.dataTransfer.setData('application/json+package', JSON.stringify(j));
-  setTimeout(() => {
-    dropdown.classList.remove('open');
-    packagesSubpage.classList.remove('open');
-    inventorySubpage.classList.remove('open');
-    avatarSubpage.classList.remove('open');
-    document.body.classList.add('dragging-package');
-  });
-};
-const _bindPackage = (pE, pJ) => {
-  const {name, dataHash} = pJ;
-  const iconHash = pJ.icons.find(i => i.type === 'image/gif').hash;
-  pE.addEventListener('dragstart', e => {
-    _startPackageDrag(e, {name, dataHash, iconHash});
-  });
-  const addButton = pE.querySelector('.add-button');
-  addButton.addEventListener('click', async () => {
-    const p = await XRPackage.download(dataHash);
-    await addPackage(p, undefined, pe);
-  });
-  const wearButton = pE.querySelector('.wear-button');
-  wearButton.addEventListener('click', () => {
-    loginManager.setAvatar(dataHash);
-  });
-  /* const inspectButton = pE.querySelector('.inspect-button');
-  inspectButton.addEventListener('click', e => {
-    e.preventDefault();
-    console.log('open', inspectButton.getAttribute('href'));
-    window.open(inspectButton.getAttribute('href'), '_blank');
-  }); */
-};
-const packages = document.getElementById('packages');
-(async () => {
-let s;
-  const res = await fetch(packagesEndpoint);
-  s = await res.text();
-  const children = JSON.parse(s);
-  const ps = await Promise.all(children.map(child =>
-    fetch(packagesEndpoint + '/' + child)
-      .then(res => res.json())
-  ));
-  packages.innerHTML = ps.map(p => _makePackageHtml(p)).join('\n');
-  Array.from(packages.querySelectorAll('.package')).forEach((pe, i) => _bindPackage(pe, ps[i]));
-
-  // wristMenu.packageSide.setPackages(ps);
-})();
 const tokens = document.getElementById('tokens');
 async function getTokenByIndex(index) {
   const metadataHash = await contract.methods.getMetadata(index, 'hash').call();
@@ -1350,7 +1178,7 @@ const _renderObjects = () => {
         URL.revokeObjectURL(u);
       };
       img.addEventListener('dragstart', e => {
-        _startPackageDrag(e, {
+        startPackageDrag(e, {
           name: p.name,
           id: p.id,
         });
@@ -1483,3 +1311,4 @@ handleUrl(window.location.href, pe);
 attachEventListeners();
 dragHandlers(pe, loginManager);
 worldHandlers(pe);
+packagesHandlers();

--- a/edit.js
+++ b/edit.js
@@ -13,7 +13,7 @@ import {handleUrl, addPackage} from './edit/utils.js';
 import attachEventListeners from './edit/classlistHandlers.js';
 import dragHandlers from './edit/dragHandlers.js';
 import {updateWorldSaveButton, worldHandlers} from './edit/worlds.js';
-import {apiHost, contract, loadMeshMaterial} from './edit/constants.js';
+import {apiHost, loadMeshMaterial} from './edit/constants.js';
 import {ensureLoadMesh, ensurePlaceholdMesh, ensureVolumeMesh} from './edit/meshes.js';
 import {packagesHandlers, startPackageDrag} from './edit/packagesHandlers.js';
 import {
@@ -856,7 +856,7 @@ for (let i = 0; i < tabs.length; i++) {
 }
 
 const tokens = document.getElementById('tokens');
-async function getTokenByIndex(index) {
+/* async function getTokenByIndex(index) {
   const metadataHash = await contract.methods.getMetadata(index, 'hash').call();
   const metadata = await fetch(`${apiHost}/${metadataHash}`).then(res => res.json());
   const {dataHash, screenshotHash, modelHash} = metadata;
@@ -868,7 +868,7 @@ async function getTokenByIndex(index) {
     dataHash: dataHash,
     modelHash: modelHash,
   };
-}
+} */
 pe.domElement.addEventListener('dragover', e => {
   e.preventDefault();
 });

--- a/edit.js
+++ b/edit.js
@@ -10,11 +10,11 @@ import {wireframeMaterial, getWireframeMesh, meshIdToArray, decorateRaycastMesh,
 import {makeLineMesh, makeTeleportMesh} from './teleport.js';
 
 import {handleUrl, addPackage} from './edit/utils.js';
-import targetMeshGeometry from './edit/targetMeshGeometry.js';
 import attachEventListeners from './edit/classlistHandlers.js';
 import dragHandlers from './edit/dragHandlers.js';
 import {updateWorldSaveButton, worldHandlers} from './edit/worlds.js';
-import {apiHost, packagesEndpoint, contract} from './edit/constants.js';
+import {apiHost, packagesEndpoint, contract, loadMeshMaterial} from './edit/constants.js';
+import {ensureLoadMesh, ensurePlaceholdMesh, ensureVolumeMesh} from './edit/meshes.js';
 import {
   packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
   tabs, tabContents, inventorySubtabContent,
@@ -50,54 +50,6 @@ let jumpState = null;
 const _resetKeys = () => {
   for (const k in keys) {
     keys[k] = false;
-  }
-};
-
-const targetVsh = `
-  #define M_PI 3.1415926535897932384626433832795
-  uniform float uTime;
-  // varying vec2 vUv;
-  void main() {
-    float f = 1.0 + pow(sin(uTime * M_PI), 0.5) * 0.2;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position * f, 1.);
-  }
-`;
-const targetFsh = `
-  uniform float uHighlight;
-  uniform float uTime;
-  void main() {
-    float f = max(1.0 - pow(uTime, 0.5), 0.1);
-    gl_FragColor = vec4(vec3(f * uHighlight), 1.0);
-  }
-`;
-const _makeTargetMesh = p => {
-  const geometry = targetMeshGeometry;
-  const material = new THREE.ShaderMaterial({
-    uniforms: {
-      uHighlight: {
-        type: 'f',
-        value: 0,
-      },
-      uTime: {
-        type: 'f',
-        value: 0,
-      },
-    },
-    vertexShader: targetVsh,
-    fragmentShader: targetFsh,
-    // transparent: true,
-  });
-  const mesh = new THREE.Mesh(geometry, material);
-  mesh.frustumCulled = false;
-  return mesh;
-};
-const _makeVolumeMesh = async p => {
-  const volumeMesh = await p.getVolumeMesh();
-  if (volumeMesh) {
-    volumeMesh.frustumCulled = false;
-    return volumeMesh;
-  } else {
-    return new THREE.Object3D();
   }
 };
 
@@ -679,92 +631,6 @@ window.addEventListener('mouseup', e => {
   lastTeleport = false;
 });
 
-const loadVsh = `
-  #define M_PI 3.1415926535897932384626433832795
-  uniform float uTime;
-
-  mat4 rotationMatrix(vec3 axis, float angle)
-  {
-      axis = normalize(axis);
-      float s = sin(angle);
-      float c = cos(angle);
-      float oc = 1.0 - c;
-
-      return mat4(oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,  0.0,
-                  oc * axis.x * axis.y + axis.z * s,  oc * axis.y * axis.y + c,           oc * axis.y * axis.z - axis.x * s,  0.0,
-                  oc * axis.z * axis.x - axis.y * s,  oc * axis.y * axis.z + axis.x * s,  oc * axis.z * axis.z + c,           0.0,
-                  0.0,                                0.0,                                0.0,                                1.0);
-  }
-
-  void main() {
-    // float f = 1.0 + pow(sin(uTime * M_PI), 0.5) * 0.2;
-    gl_Position = projectionMatrix * modelViewMatrix * rotationMatrix(vec3(0, 0, 1), -uTime * M_PI * 2.0) * vec4(position, 1.);
-  }
-`;
-const loadFsh = `
-  uniform float uHighlight;
-  uniform float uTime;
-  void main() {
-    float f = 1.0 + max(1.0 - uTime, 0.0);
-    gl_FragColor = vec4(vec3(${new THREE.Color(0xf4511e).toArray().join(', ')}) * f, 1.0);
-  }
-`;
-const loadMeshMaterial = new THREE.ShaderMaterial({
-  uniforms: {
-    /* uHighlight: {
-      type: 'f',
-      value: 0,
-    }, */
-    uTime: {
-      type: 'f',
-      value: 0,
-    },
-  },
-  vertexShader: loadVsh,
-  fragmentShader: loadFsh,
-  side: THREE.DoubleSide,
-});
-const _makeLoadMesh = (() => {
-  const geometry = new THREE.RingBufferGeometry(0.05, 0.08, 128, 0, Math.PI / 2, Math.PI * 2 * 0.9);
-  // .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI)));
-  return () => {
-    const mesh = new THREE.Mesh(geometry, loadMeshMaterial);
-    // mesh.frustumCulled = false;
-    return mesh;
-  };
-})();
-const _ensureLoadMesh = p => {
-  if (!p.loadMesh) {
-    p.loadMesh = _makeLoadMesh();
-    p.loadMesh.matrix.copy(p.matrix).decompose(p.loadMesh.position, p.loadMesh.quaternion, p.loadMesh.scale);
-    scene.add(p.loadMesh);
-
-    p.waitForRun()
-      .then(() => {
-        p.loadMesh.visible = false;
-      });
-  }
-};
-const _ensurePlaceholdMesh = p => {
-  if (!p.placeholderBox) {
-    p.placeholderBox = _makeTargetMesh();
-    p.placeholderBox.package = p;
-    p.placeholderBox.matrix.copy(p.matrix).decompose(p.placeholderBox.position, p.placeholderBox.quaternion, p.placeholderBox.scale);
-    p.placeholderBox.visible = false;
-    scene.add(p.placeholderBox);
-  }
-};
-const _ensureVolumeMesh = async p => {
-  if (!p.volumeMesh) {
-    p.volumeMesh = await _makeVolumeMesh(p);
-    p.volumeMesh = getWireframeMesh(p.volumeMesh);
-    decorateRaycastMesh(p.volumeMesh, p.id);
-    p.volumeMesh.package = p;
-    p.volumeMesh.matrix.copy(p.matrix).decompose(p.volumeMesh.position, p.volumeMesh.quaternion, p.volumeMesh.scale);
-    p.volumeMesh.visible = false;
-    scene.add(p.volumeMesh);
-  }
-};
 shieldSlider.addEventListener('change', async e => {
   const newShieldLevel = parseInt(e.target.value, 10);
   const {packages} = pe;
@@ -820,9 +686,9 @@ const _packageadd = async e => {
     reason,
   } = e.data;
 
-  _ensureLoadMesh(p);
-  _ensurePlaceholdMesh(p);
-  await _ensureVolumeMesh(p);
+  ensureLoadMesh(p, scene);
+  ensurePlaceholdMesh(p, scene);
+  await ensureVolumeMesh(p, scene);
   _renderObjects();
 
   _bindObject(p);

--- a/edit.js
+++ b/edit.js
@@ -19,6 +19,7 @@ import {
   worldSaveButton, worldRevertButton, micButton, dropdownButton, sandboxButton, newWorldButton,
   packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
   tabs, tabContents, inventorySubtabContent,
+  scaleSlider, shieldSlider,
   runMode, editMode,
   dropdown,
 } from './edit/domElements.js';
@@ -37,6 +38,28 @@ const localQuaternion2 = new THREE.Quaternion();
 const localEuler = new THREE.Euler();
 const localMatrix = new THREE.Matrix4();
 const localMatrix2 = new THREE.Matrix4();
+
+const keys = {
+  up: false,
+  down: false,
+  left: false,
+  right: false,
+  shift: false,
+};
+
+let shieldLevel = parseInt(shieldSlider.value, 10);
+let selectedTool = 'camera';
+let currentWorldId = '';
+let hoverTarget = null;
+let selectTarget = null;
+let currentWorldChanged = false;
+let jumpState = null;
+
+const _resetKeys = () => {
+  for (const k in keys) {
+    keys[k] = false;
+  }
+};
 
 function parseQuery(queryString) {
   var query = {};
@@ -391,7 +414,6 @@ bindUploadFileButton(document.getElementById('import-scene-input'), async file =
   await pe.importScene(uint8Array);
 });
 
-let selectedTool = 'camera';
 const _getAvatarHeight = () => (pe.rig ? pe.rig.height : 1) * 0.9;
 const birdsEyeHeight = 10;
 const avatarCameraOffset = new THREE.Vector3(0, 0, -1);
@@ -515,19 +537,6 @@ document.addEventListener('pointerlockchange', e => {
   }
 });
 
-const keys = {
-  up: false,
-  down: false,
-  left: false,
-  right: false,
-  shift: false,
-};
-const _resetKeys = () => {
-  for (const k in keys) {
-    keys[k] = false;
-  }
-};
-let jumpState = null;
 window.addEventListener('keydown', e => {
   switch (e.which) {
     case 49: // 1
@@ -802,8 +811,6 @@ const _ensureVolumeMesh = async p => {
     scene.add(p.volumeMesh);
   }
 };
-const shieldSlider = document.getElementById('shield-slider');
-let shieldLevel = parseInt(shieldSlider.value, 10);
 shieldSlider.addEventListener('change', async e => {
   const newShieldLevel = parseInt(e.target.value, 10);
   const {packages} = pe;
@@ -828,7 +835,6 @@ shieldSlider.addEventListener('change', async e => {
     }
   }
 });
-const scaleSlider = document.getElementById('scale-slider');
 scaleSlider.addEventListener('change', async e => {
   const newScale = parseFloat(e.target.value);
   pe.setScale(newScale);
@@ -837,8 +843,6 @@ document.getElementById('toggle-stage-button').addEventListener('click', e => {
   floorMesh.visible = !floorMesh.visible;
 });
 
-let hoverTarget = null;
-let selectTarget = null;
 const _setSelectTarget = newSelectTarget => {
   if (selectTarget && selectTarget.control) {
     _unbindTransformControls(selectTarget);
@@ -901,7 +905,7 @@ const _packageremove = e => {
     _updateWorldSaveButton();
   }
 };
-let currentWorldChanged = false;
+
 const _updateWorldSaveButton = () => {
   if (currentWorldChanged && currentWorldId) {
     worldSaveButton.classList.remove('hidden');
@@ -1147,8 +1151,8 @@ const _makeWorldHtml = w => `
     </div>
   </div>
 `;
+
 // const headerLabel = document.getElementById('header-label');
-let currentWorldId = '';
 const _enterWorld = async worldId => {
   currentWorldId = worldId;
 

--- a/edit.js
+++ b/edit.js
@@ -8,13 +8,13 @@ import {TransformControls} from './TransformControls.js';
 import {XRPackage, pe, renderer, scene, camera, floorMesh, proxySession, getRealSession, loginManager} from './run.js';
 import {downloadFile, readFile, bindUploadFileButton} from 'https://static.xrpackage.org/xrpackage/util.js';
 import {wireframeMaterial, getWireframeMesh, meshIdToArray, decorateRaycastMesh, VolumeRaycaster} from './volume.js';
-import './gif.js';
 // import {makeWristMenu, makeHighlightMesh, makeRayMesh} from './vr-ui.js';
 import {makeLineMesh, makeTeleportMesh} from './teleport.js';
 
 import targetMeshGeometry from './edit/targetMeshGeometry.js';
 import attachEventListeners from './edit/classlistHandlers.js';
 import dragHandlers from './edit/dragHandlers.js';
+import screenshotEngine from './edit/screenshotEngine.js';
 import {
   worldSaveButton, worldRevertButton, micButton, dropdownButton, sandboxButton, newWorldButton,
   packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
@@ -1077,94 +1077,11 @@ for (let i = 0; i < inventorySubtabs.length; i++) {
   });
 } */
 
-async function screenshotEngine() {
-  const center = new THREE.Vector3(0, 0, 0);
-  const size = new THREE.Vector3(3, 3, 3);
-
-  const width = 512;
-  const height = width;
-  const gif = new GIF({
-    workers: 2,
-    quality: 10,
-  });
-  const gl = pe.proxyContext;
-  const framebuffer = (() => {
-    const fbo = gl.createFramebuffer();
-
-    const oldFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
-    const oldTex = gl.getParameter(gl.TEXTURE_BINDING_2D);
-
-    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-
-    const colorTex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, colorTex);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, colorTex, 0);
-
-    const depthTex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, depthTex);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH24_STENCIL8, width, height, 0, gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, null);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, depthTex, 0);
-
-    gl.bindFramebuffer(gl.FRAMEBUFFER, oldFbo);
-    gl.bindTexture(gl.TEXTURE_2D, oldTex);
-
-    return fbo;
-  })();
-  const camera = new THREE.PerspectiveCamera(90, width / height, 0.1, 100);
-  for (let i = 0; i < Math.PI * 2; i += Math.PI * 0.05) {
-    // render
-    camera.position.copy(center)
-      .add(new THREE.Vector3(0, size.y / 2, 0))
-      .add(new THREE.Vector3(Math.cos(i + Math.PI / 2), 0, Math.sin(i + Math.PI / 2)).multiplyScalar(Math.max(size.x, size.z) * 1.2));
-    camera.lookAt(center);
-    camera.updateMatrixWorld();
-    pe.render(
-      null,
-      width,
-      height,
-      camera.matrixWorld.toArray(new Float32Array(16)),
-      camera.projectionMatrix.toArray(new Float32Array(16)),
-      framebuffer
-    );
-    // read
-    const writeCanvas = document.createElement('canvas');
-    writeCanvas.width = width;
-    writeCanvas.height = height;
-    const writeCtx = writeCanvas.getContext('2d');
-    const imageData = writeCtx.createImageData(width, height);
-    {
-      const oldFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
-      gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-      gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, imageData.data);
-      gl.bindFramebuffer(gl.FRAMEBUFFER, oldFbo);
-    }
-    // draw
-    writeCtx.putImageData(imageData, 0, 0);
-    // flip
-    writeCtx.globalCompositeOperation = 'copy';
-    writeCtx.scale(1, -1);
-    writeCtx.translate(0, -writeCanvas.height);
-    writeCtx.drawImage(writeCanvas, 0, 0);
-    // submit
-    gif.addFrame(writeCanvas, {delay: 50});
-  }
-  gif.render();
-
-  const blob = await new Promise((resolve, reject) => {
-    gif.on('finished', resolve);
-  });
-  return blob;
-}
 worldSaveButton.addEventListener('click', async e => {
   const {name} = pe;
   const hash = await pe.uploadScene();
 
-  const screenshotBlob = await screenshotEngine();
+  const screenshotBlob = await screenshotEngine(pe);
   const {hash: previewIconHash} = await fetch(`${apiHost}/`, {
     method: 'PUT',
     body: screenshotBlob,

--- a/edit.js
+++ b/edit.js
@@ -14,6 +14,7 @@ import {makeLineMesh, makeTeleportMesh} from './teleport.js';
 
 import targetMeshGeometry from './edit/targetMeshGeometry.js';
 import attachEventListeners from './edit/classlistHandlers.js';
+import dragHandlers from './edit/dragHandlers.js';
 import {
   worldSaveButton, worldRevertButton, micButton, dropdownButton, sandboxButton, newWorldButton,
   packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
@@ -1343,64 +1344,6 @@ multiplayerButton.addEventListener('click', async e => {
   worldTools.style.visibility = null;
 }); */
 
-const dropZones = Array.from(document.querySelectorAll('.drop-zone'));
-dropZones.forEach(dropZone => {
-  dropZone.addEventListener('dragenter', e => {
-    dropZone.classList.add('hover');
-  });
-  dropZone.addEventListener('dragleave', e => {
-    dropZone.classList.remove('hover');
-  });
-});
-window.addEventListener('dragend', e => {
-  document.body.classList.remove('dragging-package');
-  dropZones.forEach(dropZone => {
-    dropZone.classList.remove('hover');
-  });
-});
-document.getElementById('inventory-drop-zone').addEventListener('drop', async e => {
-  e.preventDefault();
-
-  const jsonItem = Array.from(e.dataTransfer.items).find(i => i.type === 'application/json+package');
-  if (jsonItem) {
-    const s = await new Promise((resolve, reject) => {
-      jsonItem.getAsString(resolve);
-    });
-    const j = JSON.parse(s);
-    let {name, dataHash, id, iconHash} = j;
-    if (!dataHash) {
-      const p = pe.children.find(p => p.id === id);
-      dataHash = await p.getHash();
-    }
-
-    const inventory = loginManager.getInventory();
-    inventory.push({
-      name,
-      dataHash,
-      iconHash,
-    });
-    await loginManager.setInventory(inventory);
-  }
-});
-document.getElementById('avatar-drop-zone').addEventListener('drop', async e => {
-  e.preventDefault();
-
-  const jsonItem = Array.from(e.dataTransfer.items).find(i => i.type === 'application/json+package');
-  if (jsonItem) {
-    const s = await new Promise((resolve, reject) => {
-      jsonItem.getAsString(resolve);
-    });
-    const j = JSON.parse(s);
-    let {dataHash, id} = j;
-    if (!dataHash) {
-      const p = pe.children.find(p => p.id === id);
-      dataHash = await p.getHash();
-    }
-
-    await loginManager.setAvatar(dataHash);
-  }
-});
-
 window.addEventListener('avatarchange', e => {
   const p = e.data;
 
@@ -2143,3 +2086,4 @@ window.addEventListener('popstate', e => {
 _handleUrl(window.location.href);
 
 attachEventListeners();
+dragHandlers(pe, loginManager);

--- a/edit.js
+++ b/edit.js
@@ -15,7 +15,7 @@ import dragHandlers from './edit/dragHandlers.js';
 import {updateWorldSaveButton, worldHandlers} from './edit/worlds.js';
 import {apiHost, contract, loadMeshMaterial} from './edit/constants.js';
 import {ensureLoadMesh, ensurePlaceholdMesh, ensureVolumeMesh} from './edit/meshes.js';
-import {packagesHandlers, startPackageDrag, addPackageFromHash} from './edit/packagesHandlers.js';
+import {packagesHandlers, startPackageDrag} from './edit/packagesHandlers.js';
 import {
   tabs, tabContents,
   scaleSlider, shieldSlider,
@@ -892,7 +892,7 @@ pe.domElement.addEventListener('drop', async e => {
       );
 
       const p = await XRPackage.download(dataHash);
-      await addPackage(p, localMatrix, pe);
+      await addPackage(p, pe, localMatrix);
     }
   }
 });

--- a/edit.js
+++ b/edit.js
@@ -12,6 +12,8 @@ import './gif.js';
 // import {makeWristMenu, makeHighlightMesh, makeRayMesh} from './vr-ui.js';
 import {makeLineMesh, makeTeleportMesh} from './teleport.js';
 
+import targetMeshGeometry from './edit/targetMeshGeometry.js';
+
 const apiHost = 'https://ipfs.exokit.org/ipfs';
 const presenceEndpoint = 'wss://presence.exokit.org';
 const worldsEndpoint = 'https://worlds.exokit.org';
@@ -37,46 +39,6 @@ function parseQuery(queryString) {
   return query;
 }
 
-const targetMeshGeometry = (() => {
-  const targetGeometry = BufferGeometryUtils.mergeBufferGeometries([
-    new THREE.BoxBufferGeometry(0.03, 0.2, 0.03)
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0, -0.1, 0)),
-    new THREE.BoxBufferGeometry(0.03, 0.2, 0.03)
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, -1, 0), new THREE.Vector3(0, 0, 1))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0, 0.1)),
-    new THREE.BoxBufferGeometry(0.03, 0.2, 0.03)
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, -1, 0), new THREE.Vector3(1, 0, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0.1, 0, 0)),
-  ]);
-  return BufferGeometryUtils.mergeBufferGeometries([
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, 0.5, -0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, -1), new THREE.Vector3(0, -1, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, -0.5, -0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, 0.5, 0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(1, 0, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, 0.5, -0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(1, 0, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, 0.5, 0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))))
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(-1, 0, 0), new THREE.Vector3(0, -1, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, -0.5, 0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(1, 0, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(1, 0, 0), new THREE.Vector3(0, -1, 0))))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, -0.5, -0.5)),
-    targetGeometry.clone()
-      .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(-1, 1, 0).normalize(), new THREE.Vector3(1, -1, 0).normalize())))
-      .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, -0.5, 0.5)),
-  ]);// .applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
-})();
 const targetVsh = `
   #define M_PI 3.1415926535897932384626433832795
   uniform float uTime;
@@ -748,14 +710,14 @@ document.getElementById('export-scene-button').addEventListener('click', async e
 const loadVsh = `
   #define M_PI 3.1415926535897932384626433832795
   uniform float uTime;
-  
+
   mat4 rotationMatrix(vec3 axis, float angle)
   {
       axis = normalize(axis);
       float s = sin(angle);
       float c = cos(angle);
       float oc = 1.0 - c;
-      
+
       return mat4(oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,  0.0,
                   oc * axis.x * axis.y + axis.z * s,  oc * axis.y * axis.y + c,           oc * axis.y * axis.z - axis.x * s,  0.0,
                   oc * axis.z * axis.x - axis.y * s,  oc * axis.y * axis.z + axis.x * s,  oc * axis.z * axis.z + c,           0.0,
@@ -1963,7 +1925,7 @@ const _bindObjectDetails = p => {
     scaleY,
     scaleZ,
   } = _getObjectDetailEls();
-  
+
   const _setPosition = (e, key) => {
     p.matrix.decompose(localVector, localQuaternion, localVector2);
     localVector[key] = parseFloat(e.target.value);
@@ -2144,7 +2106,7 @@ const _renderObjects = () => {
     removeButton.addEventListener('click', e => {
       pe.remove(p);
     });
- 
+
     _updateObjectDetailsTransform(p.matrix);
     _bindObjectDetails(p);
 
@@ -2225,7 +2187,7 @@ const _renderObjects = () => {
         });
       };
       _renderChildren(objectsEl, pe.children, 0);
-      
+
       // wristMenu.objectsSide.setObjects(pe.children);
     } else {
       objectsEl.innerHTML = `<h1 class=placeholder>No objects in scene</h1>`;

--- a/edit/classlistHandlers.js
+++ b/edit/classlistHandlers.js
@@ -1,0 +1,95 @@
+import {
+  packagesButton, inventoryButton, avatarButton, worldsButton,
+  packagesSubpage, inventorySubpage, avatarSubpage, worldsSubpage,
+  packagesCloseButton, inventoryCloseButton, avatarCloseButton, worldsCloseButton,
+  dropdownButton, dropdown,
+} from './domElements.js';
+
+function attachEventListeners() {
+  worldsButton.addEventListener('click', () => {
+    worldsButton.classList.toggle('open');
+    worldsSubpage.classList.toggle('open');
+
+    dropdownButton.classList.remove('open');
+    dropdown.classList.remove('open');
+    packagesButton.classList.remove('open');
+    packagesSubpage.classList.remove('open');
+    inventoryButton.classList.remove('open');
+    inventorySubpage.classList.remove('open');
+    avatarButton.classList.remove('open');
+    avatarSubpage.classList.remove('open');
+  });
+
+  packagesButton.addEventListener('click', () => {
+    packagesButton.classList.add('open');
+    packagesSubpage.classList.add('open');
+
+    dropdownButton.classList.remove('open');
+    dropdown.classList.remove('open');
+    inventoryButton.classList.remove('open');
+    inventorySubpage.classList.remove('open');
+    worldsButton.classList.remove('open');
+    worldsSubpage.classList.remove('open');
+    avatarButton.classList.remove('open');
+    avatarSubpage.classList.remove('open');
+  });
+
+  inventoryButton.addEventListener('click', () => {
+    inventoryButton.classList.toggle('open');
+    inventorySubpage.classList.toggle('open');
+
+    dropdownButton.classList.remove('open');
+    dropdown.classList.remove('open');
+    packagesButton.classList.remove('open');
+    packagesSubpage.classList.remove('open');
+    worldsButton.classList.remove('open');
+    worldsSubpage.classList.remove('open');
+    avatarButton.classList.remove('open');
+    avatarSubpage.classList.remove('open');
+  });
+
+  avatarButton.addEventListener('click', () => {
+    avatarButton.classList.toggle('open');
+    avatarSubpage.classList.toggle('open');
+
+    dropdownButton.classList.remove('open');
+    dropdown.classList.remove('open');
+    packagesButton.classList.remove('open');
+    packagesSubpage.classList.remove('open');
+    worldsButton.classList.remove('open');
+    worldsSubpage.classList.remove('open');
+    inventoryButton.classList.remove('open');
+    inventorySubpage.classList.remove('open');
+  });
+
+  dropdownButton.addEventListener('click', () => {
+    dropdownButton.classList.toggle('open');
+    dropdown.classList.toggle('open');
+
+    worldsButton.classList.remove('open');
+    packagesButton.classList.remove('open');
+    packagesSubpage.classList.remove('open');
+    inventoryButton.classList.remove('open');
+    inventorySubpage.classList.remove('open');
+    worldsSubpage.classList.remove('open');
+    avatarButton.classList.remove('open');
+    avatarSubpage.classList.remove('open');
+  });
+
+  [worldsCloseButton, packagesCloseButton, inventoryCloseButton, avatarCloseButton].forEach(closeButton => {
+    closeButton.addEventListener('click', e => {
+      dropdownButton.classList.remove('open');
+      dropdown.classList.remove('open');
+      packagesButton.classList.remove('open');
+      packagesSubpage.classList.remove('open');
+      worldsButton.classList.remove('open');
+      worldsSubpage.classList.remove('open');
+      inventoryButton.classList.remove('open');
+      inventorySubpage.classList.remove('open');
+      avatarButton.classList.remove('open');
+      avatarSubpage.classList.remove('open');
+    });
+  });
+}
+
+export default attachEventListeners;

--- a/edit/constants.js
+++ b/edit/constants.js
@@ -1,0 +1,26 @@
+// import address from 'https://contracts.webaverse.com/address.js';
+// import abi from 'https://contracts.webaverse.com/abi.js';
+
+const apiHost = 'https://ipfs.exokit.org/ipfs';
+const presenceEndpoint = 'wss://presence.exokit.org';
+const worldsEndpoint = 'https://worlds.exokit.org';
+const packagesEndpoint = 'https://packages.exokit.org';
+// const scenesEndpoint = 'https://scenes.exokit.org';
+const network = 'rinkeby';
+const infuraApiKey = '4fb939301ec543a0969f3019d74f80c2';
+const rpcUrl = `https://${network}.infura.io/v3/${infuraApiKey}`;
+// const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+// window.web3 = web3;
+// const contract = new web3.eth.Contract(abi, address);
+
+export {
+  apiHost,
+  presenceEndpoint,
+  packagesEndpoint,
+  worldsEndpoint,
+  network,
+  infuraApiKey,
+  rpcUrl,
+  // web3,
+  // contract,
+};

--- a/edit/constants.js
+++ b/edit/constants.js
@@ -1,5 +1,6 @@
 // import address from 'https://contracts.webaverse.com/address.js';
 // import abi from 'https://contracts.webaverse.com/abi.js';
+import * as THREE from 'https://static.xrpackage.org/xrpackage/three.module.js';
 
 const apiHost = 'https://ipfs.exokit.org/ipfs';
 const presenceEndpoint = 'wss://presence.exokit.org';
@@ -13,6 +14,54 @@ const rpcUrl = `https://${network}.infura.io/v3/${infuraApiKey}`;
 // window.web3 = web3;
 // const contract = new web3.eth.Contract(abi, address);
 
+const loadVsh = `
+  #define M_PI 3.1415926535897932384626433832795
+  uniform float uTime;
+
+  mat4 rotationMatrix(vec3 axis, float angle)
+  {
+      axis = normalize(axis);
+      float s = sin(angle);
+      float c = cos(angle);
+      float oc = 1.0 - c;
+
+      return mat4(oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,  0.0,
+                  oc * axis.x * axis.y + axis.z * s,  oc * axis.y * axis.y + c,           oc * axis.y * axis.z - axis.x * s,  0.0,
+                  oc * axis.z * axis.x - axis.y * s,  oc * axis.y * axis.z + axis.x * s,  oc * axis.z * axis.z + c,           0.0,
+                  0.0,                                0.0,                                0.0,                                1.0);
+  }
+
+  void main() {
+    // float f = 1.0 + pow(sin(uTime * M_PI), 0.5) * 0.2;
+    gl_Position = projectionMatrix * modelViewMatrix * rotationMatrix(vec3(0, 0, 1), -uTime * M_PI * 2.0) * vec4(position, 1.);
+  }
+`;
+
+const loadFsh = `
+  uniform float uHighlight;
+  uniform float uTime;
+  void main() {
+    float f = 1.0 + max(1.0 - uTime, 0.0);
+    gl_FragColor = vec4(vec3(${new THREE.Color(0xf4511e).toArray().join(', ')}) * f, 1.0);
+  }
+`;
+
+const loadMeshMaterial = new THREE.ShaderMaterial({
+  uniforms: {
+    /* uHighlight: {
+      type: 'f',
+      value: 0,
+    }, */
+    uTime: {
+      type: 'f',
+      value: 0,
+    },
+  },
+  vertexShader: loadVsh,
+  fragmentShader: loadFsh,
+  side: THREE.DoubleSide,
+});
+
 export {
   apiHost,
   presenceEndpoint,
@@ -23,4 +72,6 @@ export {
   rpcUrl,
   // web3,
   // contract,
+
+  loadMeshMaterial,
 };

--- a/edit/domElements.js
+++ b/edit/domElements.js
@@ -1,0 +1,63 @@
+const runMode = document.getElementById('run-mode');
+const editMode = document.getElementById('edit-mode');
+
+const worldsButton = document.getElementById('worlds-button');
+const worldSaveButton = document.getElementById('world-save-button');
+const worldRevertButton = document.getElementById('world-revert-button');
+const packagesButton = document.getElementById('packages-button');
+const inventoryButton = document.getElementById('inventory-button');
+const avatarButton = document.getElementById('avatar-button');
+const micButton = document.getElementById('mic-button');
+const dropdownButton = document.getElementById('dropdown-button');
+const dropdown = document.getElementById('dropdown');
+const worldsSubpage = document.getElementById('worlds-subpage');
+const packagesSubpage = document.getElementById('packages-subpage');
+const inventorySubpage = document.getElementById('inventory-subpage');
+const avatarSubpage = document.getElementById('avatar-subpage');
+const avatarSubpageContent = avatarSubpage.querySelector('.subtab-content');
+const tabs = Array.from(dropdown.querySelectorAll('.tab'));
+const tabContents = Array.from(dropdown.querySelectorAll('.tab-content'));
+const worldsSubtabs = Array.from(worldsSubpage.querySelectorAll('.subtab'));
+const worldsCloseButton = worldsSubpage.querySelector('.close-button');
+const worldsSubtabContents = Array.from(worldsSubpage.querySelectorAll('.subtab-content'));
+const packagesCloseButton = packagesSubpage.querySelector('.close-button');
+const inventorySubtabs = Array.from(inventorySubpage.querySelectorAll('.subtab'));
+const inventoryCloseButton = inventorySubpage.querySelector('.close-button');
+const inventorySubtabContent = inventorySubpage.querySelector('.subtab-content');
+const avatarCloseButton = avatarSubpage.querySelector('.close-button');
+
+const sandboxButton = document.getElementById('sandbox-button');
+const newWorldButton = document.getElementById('new-world-button');
+
+export {
+  runMode,
+  editMode,
+
+  worldsButton,
+  worldSaveButton,
+  worldRevertButton,
+  packagesButton,
+  inventoryButton,
+  avatarButton,
+  micButton,
+  dropdownButton,
+  dropdown,
+  worldsSubpage,
+  packagesSubpage,
+  inventorySubpage,
+  avatarSubpage,
+  avatarSubpageContent,
+  tabs,
+  tabContents,
+  worldsSubtabs,
+  worldsCloseButton,
+  worldsSubtabContents,
+  packagesCloseButton,
+  inventorySubtabs,
+  inventoryCloseButton,
+  inventorySubtabContent,
+  avatarCloseButton,
+
+  sandboxButton,
+  newWorldButton,
+};

--- a/edit/domElements.js
+++ b/edit/domElements.js
@@ -26,6 +26,9 @@ const inventoryCloseButton = inventorySubpage.querySelector('.close-button');
 const inventorySubtabContent = inventorySubpage.querySelector('.subtab-content');
 const avatarCloseButton = avatarSubpage.querySelector('.close-button');
 
+const scaleSlider = document.getElementById('scale-slider');
+const shieldSlider = document.getElementById('shield-slider');
+
 const sandboxButton = document.getElementById('sandbox-button');
 const newWorldButton = document.getElementById('new-world-button');
 
@@ -57,6 +60,9 @@ export {
   inventoryCloseButton,
   inventorySubtabContent,
   avatarCloseButton,
+
+  scaleSlider,
+  shieldSlider,
 
   sandboxButton,
   newWorldButton,

--- a/edit/dragHandlers.js
+++ b/edit/dragHandlers.js
@@ -1,0 +1,64 @@
+function dragHandlers(pe, loginManager) {
+  const dropZones = Array.from(document.querySelectorAll('.drop-zone'));
+  dropZones.forEach(dropZone => {
+    dropZone.addEventListener('dragenter', e => {
+      dropZone.classList.add('hover');
+    });
+    dropZone.addEventListener('dragleave', e => {
+      dropZone.classList.remove('hover');
+    });
+  });
+
+  window.addEventListener('dragend', e => {
+    document.body.classList.remove('dragging-package');
+    dropZones.forEach(dropZone => {
+      dropZone.classList.remove('hover');
+    });
+  });
+
+  document.getElementById('inventory-drop-zone').addEventListener('drop', async e => {
+    e.preventDefault();
+
+    const jsonItem = Array.from(e.dataTransfer.items).find(i => i.type === 'application/json+package');
+    if (jsonItem) {
+      const s = await new Promise((resolve, reject) => {
+        jsonItem.getAsString(resolve);
+      });
+      const j = JSON.parse(s);
+      let {name, dataHash, id, iconHash} = j;
+      if (!dataHash) {
+        const p = pe.children.find(p => p.id === id);
+        dataHash = await p.getHash();
+      }
+
+      const inventory = loginManager.getInventory();
+      inventory.push({
+        name,
+        dataHash,
+        iconHash,
+      });
+      await loginManager.setInventory(inventory);
+    }
+  });
+
+  document.getElementById('avatar-drop-zone').addEventListener('drop', async e => {
+    e.preventDefault();
+
+    const jsonItem = Array.from(e.dataTransfer.items).find(i => i.type === 'application/json+package');
+    if (jsonItem) {
+      const s = await new Promise((resolve, reject) => {
+        jsonItem.getAsString(resolve);
+      });
+      const j = JSON.parse(s);
+      let {dataHash, id} = j;
+      if (!dataHash) {
+        const p = pe.children.find(p => p.id === id);
+        dataHash = await p.getHash();
+      }
+
+      await loginManager.setAvatar(dataHash);
+    }
+  });
+}
+
+export default dragHandlers;

--- a/edit/meshes.js
+++ b/edit/meshes.js
@@ -1,7 +1,7 @@
 import * as THREE from 'https://static.xrpackage.org/xrpackage/three.module.js';
-import {getWireframeMesh, decorateRaycastMesh} from './volume.js';
+import {getWireframeMesh, decorateRaycastMesh} from '../volume.js';
 import {loadMeshMaterial} from './constants.js';
-import targetMeshGeometry from './edit/targetMeshGeometry.js';
+import targetMeshGeometry from './targetMeshGeometry.js';
 
 const targetVsh = `
 #define M_PI 3.1415926535897932384626433832795

--- a/edit/meshes.js
+++ b/edit/meshes.js
@@ -1,0 +1,102 @@
+import * as THREE from 'https://static.xrpackage.org/xrpackage/three.module.js';
+import {getWireframeMesh, decorateRaycastMesh} from './volume.js';
+import {loadMeshMaterial} from './constants.js';
+import targetMeshGeometry from './edit/targetMeshGeometry.js';
+
+const targetVsh = `
+#define M_PI 3.1415926535897932384626433832795
+uniform float uTime;
+// varying vec2 vUv;
+void main() {
+  float f = 1.0 + pow(sin(uTime * M_PI), 0.5) * 0.2;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position * f, 1.);
+}
+`;
+
+const targetFsh = `
+uniform float uHighlight;
+uniform float uTime;
+void main() {
+  float f = max(1.0 - pow(uTime, 0.5), 0.1);
+  gl_FragColor = vec4(vec3(f * uHighlight), 1.0);
+}
+`;
+
+const _makeTargetMesh = p => {
+  const geometry = targetMeshGeometry;
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      uHighlight: {
+        type: 'f',
+        value: 0,
+      },
+      uTime: {
+        type: 'f',
+        value: 0,
+      },
+    },
+    vertexShader: targetVsh,
+    fragmentShader: targetFsh,
+  // transparent: true,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.frustumCulled = false;
+  return mesh;
+};
+
+const _makeVolumeMesh = async p => {
+  const volumeMesh = await p.getVolumeMesh();
+  if (volumeMesh) {
+    volumeMesh.frustumCulled = false;
+    return volumeMesh;
+  } else {
+    return new THREE.Object3D();
+  }
+};
+
+const _makeLoadMesh = (() => {
+  const geometry = new THREE.RingBufferGeometry(0.05, 0.08, 128, 0, Math.PI / 2, Math.PI * 2 * 0.9);
+  // .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI)));
+  return () => {
+    const mesh = new THREE.Mesh(geometry, loadMeshMaterial);
+    // mesh.frustumCulled = false;
+    return mesh;
+  };
+})();
+
+const ensureLoadMesh = (p, scene) => {
+  if (!p.loadMesh) {
+    p.loadMesh = _makeLoadMesh();
+    p.loadMesh.matrix.copy(p.matrix).decompose(p.loadMesh.position, p.loadMesh.quaternion, p.loadMesh.scale);
+    scene.add(p.loadMesh);
+
+    p.waitForRun()
+      .then(() => {
+        p.loadMesh.visible = false;
+      });
+  }
+};
+
+const ensurePlaceholdMesh = (p, scene) => {
+  if (!p.placeholderBox) {
+    p.placeholderBox = _makeTargetMesh();
+    p.placeholderBox.package = p;
+    p.placeholderBox.matrix.copy(p.matrix).decompose(p.placeholderBox.position, p.placeholderBox.quaternion, p.placeholderBox.scale);
+    p.placeholderBox.visible = false;
+    scene.add(p.placeholderBox);
+  }
+};
+
+const ensureVolumeMesh = async (p, scene) => {
+  if (!p.volumeMesh) {
+    p.volumeMesh = await _makeVolumeMesh(p);
+    p.volumeMesh = getWireframeMesh(p.volumeMesh);
+    decorateRaycastMesh(p.volumeMesh, p.id);
+    p.volumeMesh.package = p;
+    p.volumeMesh.matrix.copy(p.matrix).decompose(p.volumeMesh.position, p.volumeMesh.quaternion, p.volumeMesh.scale);
+    p.volumeMesh.visible = false;
+    scene.add(p.volumeMesh);
+  }
+};
+
+export {ensureLoadMesh, ensurePlaceholdMesh, ensureVolumeMesh};

--- a/edit/packagesHandlers.js
+++ b/edit/packagesHandlers.js
@@ -1,0 +1,196 @@
+import {XRPackage, pe, loginManager} from '../run.js';
+import {apiHost, packagesEndpoint} from './constants.js';
+import {addPackage} from './utils.js';
+import {
+  packagesSubpage, inventorySubpage, avatarSubpage, avatarSubpageContent,
+  inventorySubtabContent, dropdown,
+} from './domElements.js';
+
+const _changeInventory = inventory => {
+  inventorySubtabContent.innerHTML = inventory.map(item => `\
+    <div class=item draggable=true>
+      <img class=screenshot>
+      <div class=name>${item.name}</div>
+      <div class=details>
+        <a class="button inspect-button" target="_blank" href="inspect.html?h=${item.hash}">Inspect</a>
+        <nav class="button wear-button">Wear</nav>
+        <nav class="button remove-button">Remove</nav>
+      </div>
+    </div>
+  `).join('\n');
+  const is = inventorySubtabContent.querySelectorAll('.item');
+  is.forEach((itemEl, i) => {
+    const item = inventory[i];
+    const {name, dataHash, iconHash} = item;
+
+    itemEl.addEventListener('dragstart', e => {
+      startPackageDrag(e, {
+        name,
+        dataHash,
+        iconHash,
+      });
+    });
+
+    (async () => {
+      const img = itemEl.querySelector('.screenshot');
+      /* if (p) {
+        const u = await p.getScreenshotImageUrl();
+        img.src = u;
+        img.onload = () => {
+          URL.revokeObjectURL(u);
+        };
+        img.onerror = err => {
+          console.warn(err);
+          URL.revokeObjectURL(u);
+        };
+      } else { */
+      img.src = `${apiHost}/${iconHash}.gif`;
+      // }
+    })();
+    const wearButton = itemEl.querySelector('.wear-button');
+    wearButton.addEventListener('click', () => {
+      loginManager.setAvatar(dataHash);
+    });
+    const removeButton = itemEl.querySelector('.remove-button');
+    removeButton.addEventListener('click', async () => {
+      console.log('remove', item);
+      const newInventory = inventory.filter(i => i.dataHash !== item.dataHash);
+      await loginManager.setInventory(newInventory);
+    });
+  });
+};
+
+const _makePackageHtml = p => `
+  <div class=package draggable=true>
+    <!-- <img src="assets/question.png"> -->
+    <img src="${apiHost}/${p.icons[0].hash}.gif" width=256 height=256>
+    <div class=text>
+      <div class=name>${p.name}</div>
+    </div>
+    <div class=background>
+      <nav class="button add-button">Add</nav>
+      <nav class="button wear-button">Wear</nav>
+      <a class="button inspect-button" target="_blank" href="inspect.html?p=${p.name}">Inspect</a>
+    </div>
+  </div>
+`;
+
+const addPackageFromHash = async (hash, matrix) => {
+  const p = await XRPackage.download(hash);
+  p.hash = hash;
+  if (matrix) {
+    p.setMatrix(matrix);
+  }
+  await pe.add(p);
+};
+
+const startPackageDrag = (e, j) => {
+  e.dataTransfer.setData('application/json+package', JSON.stringify(j));
+  setTimeout(() => {
+    dropdown.classList.remove('open');
+    packagesSubpage.classList.remove('open');
+    inventorySubpage.classList.remove('open');
+    avatarSubpage.classList.remove('open');
+    document.body.classList.add('dragging-package');
+  });
+};
+
+const _bindPackage = (pE, pJ) => {
+  const {name, dataHash} = pJ;
+  const iconHash = pJ.icons.find(i => i.type === 'image/gif').hash;
+  pE.addEventListener('dragstart', e => {
+    startPackageDrag(e, {name, dataHash, iconHash});
+  });
+  const addButton = pE.querySelector('.add-button');
+  addButton.addEventListener('click', async () => {
+    const p = await XRPackage.download(dataHash);
+    await addPackage(p, undefined, pe);
+  });
+  const wearButton = pE.querySelector('.wear-button');
+  wearButton.addEventListener('click', () => {
+    loginManager.setAvatar(dataHash);
+  });
+  /* const inspectButton = pE.querySelector('.inspect-button');
+  inspectButton.addEventListener('click', e => {
+    e.preventDefault();
+    console.log('open', inspectButton.getAttribute('href'));
+    window.open(inspectButton.getAttribute('href'), '_blank');
+  }); */
+};
+
+function packagesHandlers() {
+  _changeInventory(loginManager.getInventory());
+  loginManager.addEventListener('inventorychange', async e => {
+    const inventory = e.data;
+    _changeInventory(inventory);
+  });
+
+  const packages = document.getElementById('packages');
+  (async () => {
+    const res = await fetch(packagesEndpoint);
+    const children = await res.json();
+    const ps = await Promise.all(children.map(child =>
+      fetch(packagesEndpoint + '/' + child)
+        .then(res => res.json()),
+    ));
+    packages.innerHTML = ps.map(p => _makePackageHtml(p)).join('\n');
+    Array.from(packages.querySelectorAll('.package')).forEach((pe, i) => _bindPackage(pe, ps[i]));
+
+    // wristMenu.packageSide.setPackages(ps);
+  })();
+
+  window.addEventListener('avatarchange', e => {
+    const p = e.data;
+
+    avatarSubpageContent.innerHTML = `\
+    <div class=avatar draggable=true>
+      <img class=screenshot style="display: none;">
+      <div class=wrap>
+        ${p ? `\
+          <div class=name>${p.name}</div>
+          <div class=hash>${p.hash}</div>
+          <nav class="button unwear-button">Unwear</nab>
+        ` : `\
+          <div class=name>No avatar</div>
+        `}
+      </div>
+    </div>
+  `;
+    if (p) {
+      avatarSubpageContent.addEventListener('dragstart', e => {
+        startPackageDrag(e, {
+          name: p.name,
+          dataHash: p.hash,
+          iconHash: null,
+        });
+      });
+      (async () => {
+        const img = avatarSubpageContent.querySelector('.screenshot');
+        const u = await p.getScreenshotImageUrl();
+        if (u) {
+          img.src = u;
+          img.onload = () => {
+            img.style.display = null;
+            URL.revokeObjectURL(u);
+          };
+          img.onerror = err => {
+            console.warn(err);
+            URL.revokeObjectURL(u);
+          };
+        } /* else {
+        img.src = 'assets/question.png';
+      } */
+      })();
+      const unwearButton = avatarSubpageContent.querySelector('.unwear-button');
+      unwearButton && unwearButton.addEventListener('click', e => {
+        loginManager.setAvatar(null);
+      });
+    }
+  });
+}
+
+export {
+  packagesHandlers,
+  addPackageFromHash,
+  startPackageDrag,
+};

--- a/edit/packagesHandlers.js
+++ b/edit/packagesHandlers.js
@@ -75,15 +75,6 @@ const _makePackageHtml = p => `
   </div>
 `;
 
-const addPackageFromHash = async (hash, matrix) => {
-  const p = await XRPackage.download(hash);
-  p.hash = hash;
-  if (matrix) {
-    p.setMatrix(matrix);
-  }
-  await pe.add(p);
-};
-
 const startPackageDrag = (e, j) => {
   e.dataTransfer.setData('application/json+package', JSON.stringify(j));
   setTimeout(() => {
@@ -104,7 +95,7 @@ const _bindPackage = (pE, pJ) => {
   const addButton = pE.querySelector('.add-button');
   addButton.addEventListener('click', async () => {
     const p = await XRPackage.download(dataHash);
-    await addPackage(p, undefined, pe);
+    await addPackage(p, pe);
   });
   const wearButton = pE.querySelector('.wear-button');
   wearButton.addEventListener('click', () => {
@@ -189,8 +180,4 @@ function packagesHandlers() {
   });
 }
 
-export {
-  packagesHandlers,
-  addPackageFromHash,
-  startPackageDrag,
-};
+export {packagesHandlers, startPackageDrag};

--- a/edit/packagesHandlers.js
+++ b/edit/packagesHandlers.js
@@ -119,7 +119,8 @@ function packagesHandlers() {
   const packages = document.getElementById('packages');
   (async () => {
     const res = await fetch(packagesEndpoint);
-    const children = await res.json();
+    const s = await res.text();
+    const children = JSON.parse(s);
     const ps = await Promise.all(children.map(child =>
       fetch(packagesEndpoint + '/' + child)
         .then(res => res.json()),

--- a/edit/screenshotEngine.js
+++ b/edit/screenshotEngine.js
@@ -1,0 +1,89 @@
+/* global GIF */
+
+import * as THREE from 'https://static.xrpackage.org/xrpackage/three.module.js';
+import '../gif.js';
+
+async function screenshotEngine(pe) {
+  const center = new THREE.Vector3(0, 0, 0);
+  const size = new THREE.Vector3(3, 3, 3);
+
+  const width = 512;
+  const height = width;
+  const gif = new GIF({workers: 2, quality: 10});
+  const gl = pe.proxyContext;
+
+  const framebuffer = (() => {
+    const fbo = gl.createFramebuffer();
+
+    const oldFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+    const oldTex = gl.getParameter(gl.TEXTURE_BINDING_2D);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+
+    const colorTex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, colorTex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, colorTex, 0);
+
+    const depthTex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, depthTex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH24_STENCIL8, width, height, 0, gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, null);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, depthTex, 0);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, oldFbo);
+    gl.bindTexture(gl.TEXTURE_2D, oldTex);
+
+    return fbo;
+  })();
+
+  const camera = new THREE.PerspectiveCamera(90, width / height, 0.1, 100);
+  for (let i = 0; i < Math.PI * 2; i += Math.PI * 0.05) {
+    // render
+    camera.position.copy(center)
+      .add(new THREE.Vector3(0, size.y / 2, 0))
+      .add(new THREE.Vector3(Math.cos(i + Math.PI / 2), 0, Math.sin(i + Math.PI / 2)).multiplyScalar(Math.max(size.x, size.z) * 1.2));
+    camera.lookAt(center);
+    camera.updateMatrixWorld();
+    pe.render(
+      null,
+      width,
+      height,
+      camera.matrixWorld.toArray(new Float32Array(16)),
+      camera.projectionMatrix.toArray(new Float32Array(16)),
+      framebuffer,
+    );
+    // read
+    const writeCanvas = document.createElement('canvas');
+    writeCanvas.width = width;
+    writeCanvas.height = height;
+    const writeCtx = writeCanvas.getContext('2d');
+    const imageData = writeCtx.createImageData(width, height);
+    {
+      const oldFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+      gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+      gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, imageData.data);
+      gl.bindFramebuffer(gl.FRAMEBUFFER, oldFbo);
+    }
+    // draw
+    writeCtx.putImageData(imageData, 0, 0);
+    // flip
+    writeCtx.globalCompositeOperation = 'copy';
+    writeCtx.scale(1, -1);
+    writeCtx.translate(0, -writeCanvas.height);
+    writeCtx.drawImage(writeCanvas, 0, 0);
+    // submit
+    gif.addFrame(writeCanvas, {delay: 50});
+  }
+  gif.render();
+
+  const blob = await new Promise((resolve, reject) => {
+    gif.on('finished', resolve);
+  });
+  return blob;
+}
+
+export default screenshotEngine;

--- a/edit/targetMeshGeometry.js
+++ b/edit/targetMeshGeometry.js
@@ -1,0 +1,42 @@
+import * as THREE from 'https://static.xrpackage.org/xrpackage/three.module.js';
+import {BufferGeometryUtils} from 'https://static.xrpackage.org/BufferGeometryUtils.js';
+
+const targetGeometry = BufferGeometryUtils.mergeBufferGeometries([
+  new THREE.BoxBufferGeometry(0.03, 0.2, 0.03)
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0, -0.1, 0)),
+  new THREE.BoxBufferGeometry(0.03, 0.2, 0.03)
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, -1, 0), new THREE.Vector3(0, 0, 1))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0, 0.1)),
+  new THREE.BoxBufferGeometry(0.03, 0.2, 0.03)
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, -1, 0), new THREE.Vector3(1, 0, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0.1, 0, 0)),
+]);
+
+export default BufferGeometryUtils.mergeBufferGeometries([
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, 0.5, -0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, -1), new THREE.Vector3(0, -1, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, -0.5, -0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, 0.5, 0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(1, 0, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, 0.5, -0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(1, 0, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, 0.5, 0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))))
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(-1, 0, 0), new THREE.Vector3(0, -1, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(-0.5, -0.5, 0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(1, 0, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(1, 0, 0), new THREE.Vector3(0, -1, 0))))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, -0.5, -0.5)),
+  targetGeometry.clone()
+    .applyMatrix4(new THREE.Matrix4().makeRotationFromQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(-1, 1, 0).normalize(), new THREE.Vector3(1, -1, 0).normalize())))
+    .applyMatrix4(new THREE.Matrix4().makeTranslation(0.5, -0.5, 0.5)),
+]);// .applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0.5, 0));

--- a/edit/utils.js
+++ b/edit/utils.js
@@ -1,0 +1,62 @@
+import {enterWorld} from './worlds.js';
+import {XRPackage} from '../run.js';
+import {packagesEndpoint, apiHost, contract} from './constants.js';
+
+function parseQuery(queryString) {
+  var query = {};
+  var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+  for (var i = 0; i < pairs.length; i++) {
+    var pair = pairs[i].split('=');
+    query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+  }
+  return query;
+}
+
+const addPackage = async (p, matrix, pe) => {
+  if (matrix) {
+    p.setMatrix(matrix);
+  }
+  await pe.add(p);
+};
+
+const handleUrl = async (u, pe) => {
+  const {search} = new URL(u);
+  const q = parseQuery(search);
+
+  if (q.p) { // package
+    const metadata = await fetch(packagesEndpoint + '/' + q.p)
+      .then(res => res.json());
+    const {dataHash} = metadata;
+
+    const arrayBuffer = await fetch(`${apiHost}/${dataHash}.wbn`)
+      .then(res => res.arrayBuffer());
+
+    const p = new XRPackage(new Uint8Array(arrayBuffer));
+    await addPackage(p, pe);
+  } else if (q.i) { // index
+    const metadataHash = await contract.methods.getMetadata(parseInt(q.i, 10), 'hash').call();
+    const metadata = await fetch(`${apiHost}/${metadataHash}`)
+      .then(res => res.json());
+    const {dataHash} = metadata;
+
+    const arrayBuffer = await fetch(`${apiHost}/${dataHash}.wbn`)
+      .then(res => res.arrayBuffer());
+
+    const p = new XRPackage(new Uint8Array(arrayBuffer));
+    await addPackage(p, pe);
+  } else if (q.u) { // url
+    const arrayBuffer = await fetch(q.u)
+      .then(res => res.arrayBuffer());
+
+    const p = new XRPackage(new Uint8Array(arrayBuffer));
+    await pe.add(p);
+  } else if (q.h) { // hash
+    const p = await XRPackage.download(q.h);
+    await addPackage(p, pe);
+  } else {
+    const w = q.w || null;
+    enterWorld(w, pe);
+  }
+};
+
+export {handleUrl, addPackage};

--- a/edit/utils.js
+++ b/edit/utils.js
@@ -1,6 +1,6 @@
 import {enterWorld} from './worlds.js';
 import {XRPackage} from '../run.js';
-import {packagesEndpoint, apiHost, contract} from './constants.js';
+import {packagesEndpoint, apiHost} from './constants.js';
 
 function parseQuery(queryString) {
   var query = {};

--- a/edit/utils.js
+++ b/edit/utils.js
@@ -12,7 +12,7 @@ function parseQuery(queryString) {
   return query;
 }
 
-const addPackage = async (p, matrix, pe) => {
+const addPackage = async (p, pe, matrix) => {
   if (matrix) {
     p.setMatrix(matrix);
   }

--- a/edit/worlds.js
+++ b/edit/worlds.js
@@ -1,0 +1,233 @@
+import screenshotEngine from './screenshotEngine.js';
+import {handleUrl} from './utils.js';
+import {
+  worldSaveButton, worldRevertButton, sandboxButton, newWorldButton,
+} from './domElements.js';
+
+const apiHost = 'https://ipfs.exokit.org/ipfs';
+const worldsEndpoint = 'https://worlds.exokit.org';
+let currentWorldId = '';
+let currentWorldChanged = false;
+
+const _pushWorld = (name, pe) => {
+  history.pushState({}, '', window.location.protocol + '//' + window.location.host + window.location.pathname + (name ? ('?w=' + name) : ''));
+  handleUrl(window.location.href, pe);
+};
+
+const _makeId = length => {
+  let result = '';
+  const characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  for (var i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+  return result;
+};
+
+const _makeWorldHtml = w => `
+  <div class="world ${currentWorldId === w.id ? 'open' : ''}" worldId="${w.id}">
+    <img src=assets/question.png>
+    <div class="text">
+      <input type=text class=name-input value="${w.name}" disabled>
+    </div>
+    <div class=background>
+      <nav class="button rename-button">Rename</nav>
+    </div>
+  </div>
+`;
+
+const _bindWorld = (w, pe) => {
+  w.addEventListener('click', async e => {
+    const worldId = w.getAttribute('worldId');
+    if (worldId !== currentWorldId) {
+      _pushWorld(worldId, pe);
+    }
+  });
+  const nameInput = w.querySelector('.name-input');
+  const renameButton = w.querySelector('.rename-button');
+  let oldValue = '';
+  renameButton.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    w.classList.add('renaming');
+    oldValue = nameInput.value;
+    nameInput.removeAttribute('disabled');
+    nameInput.select();
+  });
+  nameInput.addEventListener('blur', e => {
+    nameInput.value = oldValue;
+    nameInput.setAttribute('disabled', '');
+    oldValue = '';
+  });
+  nameInput.addEventListener('keydown', e => {
+    if (e.which === 13) { // enter
+      pe.name = nameInput.value;
+      currentWorldChanged = true;
+      updateWorldSaveButton();
+
+      oldValue = nameInput.value;
+      nameInput.blur();
+    } else if (e.which === 27) { // esc
+      nameInput.blur();
+    }
+  });
+};
+
+const updateWorldSaveButton = (worldChanged) => {
+  currentWorldChanged = worldChanged;
+  if (currentWorldChanged && currentWorldId) {
+    worldSaveButton.classList.remove('hidden');
+    worldRevertButton.classList.remove('hidden');
+  } else {
+    worldSaveButton.classList.add('hidden');
+    worldRevertButton.classList.add('hidden');
+  }
+};
+
+const enterWorld = async (worldId, pe) => {
+  currentWorldId = worldId;
+
+  /* const headerLabel = document.getElementById('header-label');
+  headerLabel.innerText = name || 'Sandbox';
+  runMode.setAttribute('href', 'run.html' + (worldId ? ('?w=' + worldId) : ''));
+  editMode.setAttribute('href', 'edit.html' + (worldId ? ('?w=' + worldId) : '')); */
+
+  const worlds = Array.from(document.querySelectorAll('.world'));
+  worlds.forEach(world => world.classList.remove('open'));
+
+  let world;
+  if (worldId) {
+    world = worlds.find(w => w.getAttribute('worldId') === worldId);
+  } else {
+    world = worlds[0];
+  }
+  world && world.classList.add('open');
+
+  if (worldId) {
+    const res = await fetch(worldsEndpoint + '/' + worldId);
+    if (res.ok) {
+      const j = await res.json();
+      const {hash} = j;
+      await pe.downloadScene(hash);
+    } else {
+      console.warn('invalid world status code: ' + worldId + ' ' + res.status);
+    }
+  } else {
+    pe.reset();
+  }
+
+  currentWorldChanged = false;
+  updateWorldSaveButton();
+};
+
+function worldHandlers(pe) {
+  worldSaveButton.addEventListener('click', async e => {
+    const {name} = pe;
+    const hash = await pe.uploadScene();
+
+    const screenshotBlob = await screenshotEngine(pe);
+    const {hash: previewIconHash} = await fetch(`${apiHost}/`, {
+      method: 'PUT',
+      body: screenshotBlob,
+    })
+      .then(res => res.json());
+
+    const objects = await Promise.all(pe.children.map(async p => {
+      const {name} = p;
+      const previewIconHash = await (async () => {
+        const screenshotImgUrl = await p.getScreenshotImageUrl();
+        if (screenshotImgUrl) {
+          const screenshotBlob = await fetch(screenshotImgUrl)
+            .then(res => res.blob());
+          const {hash: previewIconHash} = await fetch(`${apiHost}/`, {
+            method: 'PUT',
+            body: screenshotBlob,
+          })
+            .then(res => res.json());
+          return previewIconHash;
+        } else {
+          return null;
+        }
+      })();
+      return {
+        name,
+        previewIconHash,
+      };
+    }));
+
+    const w = {
+      id: currentWorldId,
+      name,
+      description: 'This is a world description',
+      hash,
+      previewIconHash,
+      objects,
+    };
+
+    const res = await fetch(worldsEndpoint + '/' + currentWorldId, {
+      method: 'PUT',
+      body: JSON.stringify(w),
+    });
+
+    if (res.ok) {
+      // nothing
+    } else {
+      console.warn('invalid status code: ' + res.status);
+    }
+
+    currentWorldChanged = false;
+    updateWorldSaveButton();
+  });
+
+  worldRevertButton.addEventListener('click', async e => {
+    enterWorld(currentWorldId, pe);
+  });
+
+  sandboxButton.addEventListener('click', e => {
+    _pushWorld(null, pe);
+  });
+
+  const worlds = document.getElementById('worlds');
+  newWorldButton.addEventListener('click', async e => {
+    pe.reset();
+    const hash = await pe.uploadScene();
+
+    const worldId = _makeId(8);
+    const w = {
+      id: worldId,
+      name: worldId,
+      description: 'This is a world description',
+      hash,
+      objects: [],
+    };
+
+    const res = await fetch(worldsEndpoint + '/' + w.name, {
+      method: 'PUT',
+      body: JSON.stringify(w),
+    });
+
+    if (res.ok) {
+      worlds.innerHTML += '\n' + _makeWorldHtml(w);
+      const ws = Array.from(worlds.querySelectorAll('.world'));
+      Array.from(worlds.querySelectorAll('.world')).forEach(w => _bindWorld(w, pe));
+      const newW = ws[ws.length - 1];
+      newW.click();
+    } else {
+      console.warn('invalid status code: ' + res.status);
+    }
+  });
+
+  (async () => {
+    const res = await fetch(worldsEndpoint);
+    const children = await res.json();
+    const ws = await Promise.all(children.map(child =>
+      fetch(worldsEndpoint + '/' + child)
+        .then(res => res.json()),
+    ));
+    worlds.innerHTML = ws.map(w => _makeWorldHtml(w)).join('\n');
+    Array.from(worlds.querySelectorAll('.world')).forEach((w, i) => _bindWorld(w, pe));
+  })();
+}
+
+export {updateWorldSaveButton, worldHandlers, enterWorld};

--- a/edit/worlds.js
+++ b/edit/worlds.js
@@ -1,3 +1,5 @@
+import {downloadFile} from 'https://static.xrpackage.org/xrpackage/util.js';
+
 import screenshotEngine from './screenshotEngine.js';
 import {handleUrl} from './utils.js';
 import {
@@ -228,6 +230,127 @@ function worldHandlers(pe) {
     worlds.innerHTML = ws.map(w => _makeWorldHtml(w)).join('\n');
     Array.from(worlds.querySelectorAll('.world')).forEach((w, i) => _bindWorld(w, pe));
   })();
+
+  /* document.getElementById('world-name').addEventListener('change', e => {
+  pe.name = e.target.value;
+}); */
+  document.getElementById('reset-scene-button').addEventListener('click', e => {
+    pe.reset();
+  });
+  /* document.getElementById('publish-scene-button').addEventListener('click', async e => {
+  const hash = await pe.uploadScene();
+  const res = await fetch(scenesEndpoint + '/' + hash, {
+    method: 'PUT',
+    body: JSON.stringify({
+      name: pe.name,
+      hash,
+    }),
+  });
+  if (res.ok) {
+    // nothing
+  } else {
+    console.warn('invalid status code: ' + res.status);
+  }
+}); */
+  document.getElementById('export-scene-button').addEventListener('click', async e => {
+    const uint8Array = await pe.exportScene();
+    const b = new Blob([uint8Array], {
+      type: 'application/webbundle',
+    });
+    downloadFile(b, 'scene.wbn');
+  });
+
+  /* const worldTools = document.getElementById('world-tools');
+  const publishWorldButton = document.getElementById('publish-world-button');
+  const singleplayerButton = document.getElementById('singleplayer-button');
+  const multiplayerButton = document.getElementById('multiplayer-button');
+  let worldType = 'singleplayer';
+
+  singleplayerButton.addEventListener('click', e => {
+    pe.reset();
+
+    singleplayerButton.classList.add('open');
+    multiplayerButton.classList.remove('open');
+    Array.from(worlds.querySelectorAll('.world')).forEach(w => {
+      w.classList.remove('open');
+    });
+    worldType = 'singleplayer';
+    worldTools.style.visibility = null;
+  });
+
+  multiplayerButton.addEventListener('click', async e => {
+    pe.reset();
+
+    singleplayerButton.classList.remove('open');
+    multiplayerButton.classList.add('open');
+    Array.from(worlds.querySelectorAll('.world')).forEach(w => {
+      w.classList.remove('open');
+    });
+    worldType = 'multiplayer';
+    worldTools.style.visibility = null;
+  });
+
+  publishWorldButton.addEventListener('click', async e => {
+    let hash;
+    if (worldType === 'singleplayer') {
+      hash = await pe.uploadScene();
+    } else if (worldType === 'multiplayer') {
+      const array = new Uint8Array(32);
+      crypto.getRandomValues(array);
+      hash = Array.prototype.map.call(array, x => ('00' + x.toString(16)).slice(-2)).join('');
+    }
+
+    const w = {
+      name: 'WebXR world',
+      description: 'This is a world description',
+      hash,
+      type: worldType,
+    };
+    const res = await fetch(worldsEndpoint + '/' + hash, {
+      method: 'PUT',
+      body: JSON.stringify(w),
+    });
+    if (res.ok) {
+      worlds.innerHTML += '\n' + _makeWorldHtml(w);
+      const ws = Array.from(worlds.querySelectorAll('.world'));
+      Array.from(worlds.querySelectorAll('.world')).forEach(w => _bindWorld(w));
+      const newW = ws[ws.length - 1];
+      newW.click();
+    } else {
+      console.warn('invalid status code: ' + res.status);
+    }
+  }); */
+
+  /* for (let i = 0; i < worldsSubtabs.length; i++) {
+    const subtab = worldsSubtabs[i];
+    const subtabContent = worldsSubtabContents[i];
+    subtab.addEventListener('click', e => {
+      for (let i = 0; i < worldsSubtabs.length; i++) {
+        const subtab = worldsSubtabs[i];
+        const subtabContent = worldsSubtabContents[i];
+        subtab.classList.remove('open');
+        subtabContent.classList.remove('open');
+      }
+
+      subtab.classList.add('open');
+      subtabContent.classList.add('open');
+    });
+  }
+  for (let i = 0; i < inventorySubtabs.length; i++) {
+    const subtab = inventorySubtabs[i];
+    const subtabContent = inventorySubtabContents[i];
+    subtab.addEventListener('click', e => {
+      for (let i = 0; i < inventorySubtabs.length; i++) {
+        const subtab = inventorySubtabs[i];
+        const subtabContent = inventorySubtabContents[i];
+        subtab.classList.remove('open');
+        subtabContent.classList.remove('open');
+      }
+
+      subtab.classList.add('open');
+      subtabContent.classList.add('open');
+    });
+  } */
 }
 
 export {updateWorldSaveButton, worldHandlers, enterWorld};


### PR DESCRIPTION
It might be a bit easier to complete https://github.com/webaverse/xrpackage/issues/69 after separating out some of the core parts of logic from the edit.js file.

This PR just moves chunks of code out into their own modules to make it easier to read and follow, for example:

- Move DOM element definitions into own file
- Move constants and utilities into own file
- Move some world logic into own file
- Move UI `classlist` handlers into own file
- Move UI drag handlers into own file

I think more logic could be separated but this is a first pass attempt and more things might become obvious during the removal of run.html