### PR TITLE
Make GIFs have a transparent background

### DIFF
--- a/screenshot-object.js
+++ b/screenshot-object.js
@@ -79,6 +79,7 @@ export async function screenshotEngine(pe) {
   const gif = new GIF({
     workers: 2,
     quality: 10,
+    transparent: 'rgba(0,0,0,0)',
   });
   for (let i = 0; i < Math.PI * 2; i += Math.PI * 0.025) {
     pe.camera.position.copy(center).add(new THREE.Vector3(Math.cos(i) * size.x, size.y / 2, Math.sin(i) * size.z));


### PR DESCRIPTION
This means we can easily set the background colour to be whatever we need in different locations through a CSS `background-color` property. It might also reduce the file size.

We should probably also go through and update the existing package GIFs after this is deployed.