### PR TITLE
Take screenshot of empty world on creation & add world GIF preview to worlds panel

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -1355,7 +1355,7 @@ worldRevertButton.addEventListener('click', async e => {
 const worlds = document.getElementById('worlds');
 const _makeWorldHtml = w => `
   <div class="world ${currentWorldId === w.id ? 'open' : ''}" worldId="${w.id}">
-    <img src=assets/question.png>
+    <img src=${w.previewIconHash ? `${apiHost}/${w.previewIconHash}.gif` : 'assets/question.png'}>
     <div class="text">
       <input type=text class=name-input value="${w.name}" disabled>
     </div>

--- a/edit.js
+++ b/edit.js
@@ -1868,12 +1868,20 @@ newWorldButton.addEventListener('click', async e => {
   pe.reset();
   const hash = await pe.uploadScene();
 
+  const screenshotBlob = await screenshotEngine();
+  const {hash: previewIconHash} = await fetch(`${apiHost}/`, {
+    method: 'PUT',
+    body: screenshotBlob,
+  })
+    .then(res => res.json());
+
   const worldId = makeId(8);
   const w = {
     id: worldId,
     name: worldId,
     description: 'This is a world description',
     hash,
+    previewIconHash,
     objects: [],
   };
   const res = await fetch(worldsEndpoint + '/' + w.name, {


### PR DESCRIPTION
This PR:

- adds the preview GIF for worlds to the worlds panel on /edit.html
- takes and saves a preview GIF screenshot of worlds on _creation_, so from now on, new worlds will always have a preview (instead of the default question mark)

Before:

!['before' view of worlds panel](https://user-images.githubusercontent.com/8850830/86938176-08e86a00-c138-11ea-8dd8-439530418928.png)

After:

!['after' view of worlds panel](https://user-images.githubusercontent.com/8850830/86938137-fc641180-c137-11ea-99f0-292c71d88cc0.png)
