### PR TITLE
Add search to XRPKs panel on /edit.html; Vertical scroll instead of horizontal

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -173,6 +173,9 @@
   <aside class=subpage id=packages-subpage>
     <div class=subtabs>
       <nav class="subtab open" id=subtab-1>XRPKs</nav>
+      <div class="search">
+        <input id="packages-search" placeholder="Search" />
+      </div>
       <nav class=close-button>
         <i class="fa fa-close"></i>
       </nav>

--- a/edit.html
+++ b/edit.html
@@ -196,7 +196,7 @@
       </nav>
     </div>
     <div class=subpage-wrap>
-      <div class="subtab-content open">
+      <div class="subtab-content open inventory">
       </div>
     </div>
   </aside>

--- a/edit.html
+++ b/edit.html
@@ -137,7 +137,7 @@
       <div class=name>Enter</div>
     </nav>
   </footer>
-  <aside class=subpage id=worlds-subpage>
+  <aside class="subpage worlds-subpage" id=worlds-subpage>
     <div class=subtabs>
       <nav class=subtab id=subtab-1>Worlds</nav>
       <nav class=close-button>
@@ -163,7 +163,7 @@
               </div>
             </div>
           </div>
-          <div class=worlds id=worlds>
+          <div class="worlds worlds-list" id=worlds>
 
           </div>
         </div>
@@ -172,9 +172,11 @@
   </aside>
   <aside class=subpage id=packages-subpage>
     <div class=subtabs>
-      <nav class="subtab open" id=subtab-1>XRPKs</nav>
-      <div class="search">
-        <input id="packages-search" placeholder="Search" />
+      <div class=title>
+        <nav class="subtab open" id=subtab-1>XRPKs</nav>
+        <div class="search">
+          <input id="packages-search" placeholder="Search" class=search-input />
+        </div>
       </div>
       <nav class=close-button>
         <i class="fa fa-close"></i>

--- a/edit.js
+++ b/edit.js
@@ -1535,6 +1535,23 @@ document.getElementById('avatar-drop-zone').addEventListener('drop', async e => 
     await loginManager.setAvatar(dataHash);
   }
 });
+document.getElementById('packages-search').addEventListener('input', e => {
+  const searchTerm = e.target.value.toLowerCase();
+  const packages = [...document.querySelectorAll('#packages .package')];
+
+  if (!searchTerm) {
+    packages.forEach(p => (p.style.display = 'block'));
+    return;
+  }
+
+  packages.forEach(p => {
+    if (p.getAttribute('data-name').includes(searchTerm)) {
+      p.style.display = 'block';
+    } else {
+      p.style.display = 'none';
+    }
+  });
+});
 
 window.addEventListener('avatarchange', e => {
   const p = e.data;
@@ -1647,7 +1664,7 @@ loginManager.addEventListener('inventorychange', async e => {
 });
 
 const _makePackageHtml = p => `
-  <div class=package draggable=true>
+  <div class=package draggable=true data-name=${p.name}>
     <!-- <img src="assets/question.png"> -->
     <img src="${apiHost}/${p.icons[0].hash}.gif" width=256 height=256>
     <div class=text>

--- a/edit.js
+++ b/edit.js
@@ -1605,9 +1605,9 @@ window.addEventListener('avatarchange', e => {
 const _changeInventory = inventory => {
   inventorySubtabContent.innerHTML = inventory.map(item => `\
     <div class=item draggable=true>
-      <img class=screenshot>
+      <img class=screenshot width=256 height=256>
       <div class=name>${item.name}</div>
-      <div class=details>
+      <div class=background>
         <a class="button inspect-button" target="_blank" href="inspect.html?h=${item.dataHash}">Inspect</a>
         <nav class="button wear-button">Wear</nav>
         <nav class="button remove-button">Remove</nav>

--- a/edit.js
+++ b/edit.js
@@ -1539,18 +1539,17 @@ document.getElementById('packages-search').addEventListener('input', e => {
   const searchTerm = e.target.value.toLowerCase();
   const packages = [...document.querySelectorAll('#packages .package')];
 
-  if (!searchTerm) {
+  if (searchTerm) {
+    packages.forEach(p => {
+      if (p.getAttribute('data-name').includes(searchTerm)) {
+        p.style.display = 'block';
+      } else {
+        p.style.display = 'none';
+      }
+    });
+  } else {
     packages.forEach(p => (p.style.display = 'block'));
-    return;
   }
-
-  packages.forEach(p => {
-    if (p.getAttribute('data-name').includes(searchTerm)) {
-      p.style.display = 'block';
-    } else {
-      p.style.display = 'none';
-    }
-  });
 });
 
 window.addEventListener('avatarchange', e => {

--- a/index.css
+++ b/index.css
@@ -785,14 +785,16 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 
 } */
 
-.packages {
+.packages,
+.inventory {
   display: flex;
   overflow: auto;
   max-height: 200px;
   flex-wrap: wrap;
 }
 .packages .package,
-.worlds .world
+.worlds .world,
+.inventory .item
 {
   position: relative;
   display: inline-flex;
@@ -819,7 +821,8 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   color: #000;
 }
 .packages .package .background,
-.worlds .world .background
+.worlds .world .background,
+.inventory .item .background
 {
   position: absolute;
   top: 0;
@@ -830,7 +833,8 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   flex-direction: column;
 }
 .packages .package:not(:hover) .background,
-.worlds .world:not(:hover) .background
+.worlds .world:not(:hover) .background,
+.inventory .item:not(:hover) .background
 {
   display: none;
   padding: 10px;
@@ -838,7 +842,9 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 .packages .package img,
 .packages .package i,
 .worlds .world img,
-.worlds .world i
+.worlds .world i,
+.inventory .item img,
+.inventory .item i
 {
   display: flex;
   width: 100px;
@@ -858,7 +864,8 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   font-size: 13px;
 }
 .packages .package .button,
-.worlds .world .button
+.worlds .world .button,
+.inventory .item .button
 {
   margin-bottom: 5px;
 }
@@ -1505,7 +1512,6 @@ header.unlocking + .main .blocker .button
 }
 .details {
   display: flex;
-  width: 400px;
   flex-direction: column;
   align-items: flex-start;
 }
@@ -1787,29 +1793,4 @@ body.dragging-package .footer {
 .avatar .wrap {
   display: flex;
   flex-direction: column;
-}
-.item {
-  display: flex;
-  position: relative;
-  flex-direction: column;
-}
-.item img {
-  width: 100px;
-  height: 100px;
-  margin-right: 10px;
-  background-color: #FFF;
-  border-radius: 8px;
-}
-.item .details {
-  display: flex;
-  position: absolute;
-  top: 0;
-  left: 0;
-  flex-direction: column;
-}
-.item:not(:hover) .details {
-  display: none;
-}
-.item .details .button {
-  margin-bottom: 5px;
 }

--- a/index.css
+++ b/index.css
@@ -611,6 +611,7 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 .subtabs {
   display: flex;
   margin-bottom: 10px;
+  justify-content: space-between;
 }
 
 .subtabs .subtab {
@@ -652,9 +653,12 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   color: #FFF; */
 }
 
+.subtabs .search {
+  margin: auto;
+}
+
 .subtabs .close-button {
   display: flex;
-  margin-left: auto;
   width: 40px;
   font-size: 16px;
   justify-content: center;
@@ -778,7 +782,7 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 .worlds .world .button,
 .world-buttons .world .button
 {
-  
+
 } */
 
 .packages {

--- a/index.css
+++ b/index.css
@@ -596,7 +596,7 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   right: 0;
   bottom: 0;
   width: 100vw;
-  min-height: 200px;
+  height: 200px;
   /* padding: 20px; */
   background-color: #111;
   color: #FFF;
@@ -624,7 +624,6 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   font-size: 20px;
   justify-content: center;
   align-items: center;
-  cursor: pointer;
   user-select: none;
 }
 
@@ -656,7 +655,14 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 .subtabs .search {
   margin: auto;
 }
-
+.subtabs .search .search-input {
+  border-radius: 4px;
+  border: none;
+  padding: 4px;
+}
+.subtabs .title {
+  display: flex;
+}
 .subtabs .close-button {
   display: flex;
   width: 40px;
@@ -669,9 +675,6 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   color: #ef5350;
 }
 
-.subtab-content {
-  display: flex;
-}
 .subtab-content:not(.open) {
   display: none;
 }
@@ -786,11 +789,13 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 } */
 
 .packages,
-.inventory {
-  display: flex;
-  overflow: auto;
+.inventory,
+.worlds-list {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 120px);
   max-height: 200px;
-  flex-wrap: wrap;
+  justify-content: space-around;
 }
 .packages .package,
 .worlds .world,
@@ -798,11 +803,17 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 {
   position: relative;
   display: inline-flex;
-  margin-right: 20px;
+  margin: auto;
   margin-bottom: 20px;
   border: 5px solid transparent;
   flex-direction: column;
   cursor: pointer;
+}
+.worlds-subpage {
+  height: 400px;
+}
+.worlds {
+  text-align: center;
 }
 .worlds .world.open {
   background-color: #64b5f6;
@@ -859,7 +870,8 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
   pointer-events: none;
 }
 .packages .package .name,
-.worlds .world .name
+.worlds .world .name,
+.inventory .item .name
 {
   font-size: 13px;
 }
@@ -1469,10 +1481,7 @@ header.unlocking + .main .blocker .button
 }
 
 .subpage-wrap {
-  display: flex;
-  padding: 0 30px;
   max-height: 100vh;
-  overflow: auto;
 }
 .details-wrap {
   display: flex;

--- a/index.css
+++ b/index.css
@@ -787,6 +787,9 @@ header.builtin.import .wallet.import, header.builtin.locked .wallet.locked, head
 
 .packages {
   display: flex;
+  overflow: auto;
+  max-height: 200px;
+  flex-wrap: wrap;
 }
 .packages .package,
 .worlds .world


### PR DESCRIPTION
This PR addresses the suggestion from https://github.com/webaverse/xrpackage-site/pull/7#issuecomment-650222846:

> Also I'm thinking that inventory list will probably make more sense with a vertical scroll and a search bar, but that's a future PR.

---

- adds a search bar to the XRPKs panel on /edit.html, with results changing as you type
- makes the XPRKs panel scroll vertically instead of horizontally
- makes the styling of the inventory panel the same as the packages panel (and removes duplicate CSS)
- updates the worlds panel to not fill and overflow the entire screen

---

The packages panel now looks like:

![xrpks-search-demo](https://user-images.githubusercontent.com/8850830/87168827-f9e3f200-c2c6-11ea-873e-d521f46f0abe.gif)

---

The inventory panel now looks like:

![new inventory panel](https://user-images.githubusercontent.com/8850830/87168871-07997780-c2c7-11ea-820e-9af19e61bdbe.png)

compared to: 

![old inventory panel](https://user-images.githubusercontent.com/8850830/87028851-2587af00-c1d7-11ea-8959-02f0187d51f0.png)

---

The worlds panel now looks like:

![new worlds panel](https://user-images.githubusercontent.com/8850830/87169088-5e9f4c80-c2c7-11ea-934c-9ab7545c144c.png)

compared to:

![old worlds panel](https://user-images.githubusercontent.com/8850830/87169133-6bbc3b80-c2c7-11ea-9af9-063a62575423.png)

which was about to overflow with a few more worlds.

